### PR TITLE
Fix same day date sort

### DIFF
--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -1834,6 +1834,18 @@ function updateTaxRate() {
 	return $display_block;
 }
 
+//ensure we have a time, else add the current time to the date (to be sure invoices can be sorted by 'date desc')	
+function SqlDateWithTime($in_date){
+	list($date,$time)=explode(' ', $in_date);
+	if(!$time or $time == '00:00:00'){
+		$time=date('H:i:s');
+	}
+	$out_date="$date $time";
+	return $out_date;
+}
+
+
+
 function insertInvoice($type) {
 	global $dbh;
 	global $db_server;
@@ -1914,20 +1926,23 @@ function insertInvoice($type) {
 	//echo $sql;
     $pref_group=getPreference($_POST[preference_id]);
 
+	//also set the current time (if null or =00:00:00)
+	$clean_date=SqlDateWithTime($_POST['date']);
+
 	$sth= dbQuery($sql,
 		#':index_id', index::next('invoice',$pref_group[index_group],$_POST[biller_id]),
-		':index_id', index::next('invoice',$pref_group[index_group]),
-		':domain_id', $auth_session->domain_id,
-		':biller_id', $_POST[biller_id],
-		':customer_id', $_POST[customer_id],
-		':type', $type,
-		':preference_id', $_POST[preference_id],
-		':date', $_POST[date],
-		':note', $_POST[note],
-		':customField1', $_POST[customField1],
-		':customField2', $_POST[customField2],
-		':customField3', $_POST[customField3],
-		':customField4', $_POST[customField4]
+		':index_id',		index::next('invoice',$pref_group[index_group]),
+		':domain_id',		$auth_session->domain_id,
+		':biller_id',		$_POST[biller_id],
+		':customer_id', 	$_POST[customer_id],
+		':type', 			$type,
+		':preference_id',	$_POST[preference_id],
+		':date', 			$clean_date,
+		':note', 			$_POST[note],
+		':customField1',	$_POST[customField1],
+		':customField2',	$_POST[customField2],
+		':customField3',	$_POST[customField3],
+		':customField4',	$_POST[customField4]
 		);
 
     #index::increment('invoice',$pref_group[index_group],$_POST[biller_id]);

--- a/modules/payments/save.php
+++ b/modules/payments/save.php
@@ -14,11 +14,11 @@ global $auth_session;
 if ( isset($_POST['process_payment']) ) {
 	
 	$payment = new payment();
-	$payment->ac_inv_id = $_POST['invoice_id'];
-	$payment->ac_amount = $_POST['ac_amount'];
-	$payment->ac_notes = $_POST['ac_notes'];
-	$payment->ac_date = $_POST['ac_date'];
-	$payment->ac_payment_type = $_POST['ac_payment_type'];
+	$payment->ac_inv_id 		= $_POST['invoice_id'];
+	$payment->ac_amount 		= $_POST['ac_amount'];
+	$payment->ac_notes			= $_POST['ac_notes'];
+	$payment->ac_date			= SqlDateWithTime($_POST['ac_date']);
+	$payment->ac_payment_type	= $_POST['ac_payment_type'];
 	$result = $payment->insert();
 	
 	$saved = !empty($result) ? "true" : "false";


### PR DESCRIPTION
fixes the date Sort, when multiple invoices or payments are at the same date.

example:
Invoice (id, date)  table sorted by ID
- 1, jan 1 
- 2, fev 1 
- 3, apr 1 
- 4, apr 1 

Invoice (id, date)  table sorted by Date Desc
- 3, apr 1 <-- 
- 4, apr 1 <-- 
- 2, fev 1 
- 1, jan 1 

Invoice (id, date)  table sorted by Date Desc AFTER my Fix
- 4, apr 1 <-- 
- 3, apr 1 <-- 
- 2, fev 1 
- 1, jan 1 

---

I've just added a current time to the date on invoice or payment creation. 
If the time is provided by the jquery calendar, and not equal to "00:00:00", it will be used instead.

I can relocate or rename the SqlDateWithTime Function, as you wish.

HTH
