### PR TITLE
Fix Paid Invoices shown as owed 

### DIFF
--- a/include/class/invoice.php
+++ b/include/class/invoice.php
@@ -346,7 +346,7 @@ class invoice {
                 TB_PREFIX . "invoice_items ii WHERE ii.invoice_id = iv.id) AS invoice_total,
                        (SELECT coalesce(SUM(ac_amount), 0) FROM " .
                 TB_PREFIX . "payment ap WHERE ap.ac_inv_id = iv.id) AS INV_PAID,
-                       (SELECT (coalesce(invoice_total,0) - coalesce(INV_PAID,0))) As owing,
+                       ROUND( (SELECT (coalesce(invoice_total,0) - coalesce(INV_PAID,0))) ,2) As owing,
                        DATE_FORMAT(date,'%Y-%m-%d') AS date,
                        (SELECT IF((owing = 0 OR owing < 0), 0, DateDiff(now(), date))) AS Age,
                        (SELECT (CASE   WHEN Age = 0 THEN ''


### PR DESCRIPTION
Dont show the Paid invoice as owed (in the owed filter view) with a total owed of 0...

How to reproduce the bug :
- Create an invoice with 1 item, $70.06, VAT 19,6%
  ( total = 83.79176, rounded as 83.79 on the invoice)
- Create a payment of $83,79

--> The invoice is still shown as owed because $0.0017 are still not paid....

Rounding the owed amount in the query fixes this.
BTW I've only aplied to the mysql query, (I'm not familiar with pgsql)

HTH
