### PR TITLE
Fixed Existing Unicode Currency Character display eg., Rs - &#8360; - U+...

### DIFF
--- a/extensions/sub_customer/templates/invoices/sub_customer/template.tpl
+++ b/extensions/sub_customer/templates/invoices/sub_customer/template.tpl
@@ -63,15 +63,15 @@
         *}
 		<tr>
 				<td class="" >{$LANG.total}: </td>
-				<td class="" align="right" colspan="3">{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</td>
+				<td class="" align="right" colspan="3">{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</td>
 		</tr>
 		<tr>
 				<td class="">{$LANG.paid}:</td>
-				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign|htmlsafe}{$invoice.paid|siLocal_number}</td>
+				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign} {$invoice.paid|siLocal_number}</td>
 		</tr>
 		<tr>
 				<td nowrap class="">{$LANG.owing}:</td>
-				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign|htmlsafe}{$invoice.owing|siLocal_number}</td>
+				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign} {$invoice.owing|siLocal_number}</td>
 		</tr>
 
 	</table>
@@ -213,8 +213,8 @@
 			<tr class="" >
 				<td class="">{$invoiceItem.quantity|siLocal_number_trim}</td>
 				<td class="" colspan="3">{$invoiceItem.product.description|htmlsafe}</td>
-				<td class="" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.unit_price|siLocal_number}</td>
-				<td class="" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.gross_total|siLocal_number}</td>
+				<td class="" align="right">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+				<td class="" align="right">{$preference.pref_currency_sign} {$invoiceItem.gross_total|siLocal_number}</td>
 			</tr>
 			{if $invoiceItem.description != null}
 			<tr class="">
@@ -291,8 +291,8 @@
 				<td class=""></td>
 				<td class=""></td>
 				<td class=""></td>
-				<td align="right" class="">{$preference.pref_currency_sign}{$invoiceItem.unit_price|siLocal_number}</td>
-				<td align="right" class="">{$preference.pref_currency_sign}{$invoiceItem.total|siLocal_number}</td>
+				<td align="right" class="">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+				<td align="right" class="">{$preference.pref_currency_sign} {$invoiceItem.total|siLocal_number}</td>
 			</tr>
 			{/foreach}
 	{/if}
@@ -336,7 +336,7 @@
 	<tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.sub_total}&nbsp;</td>
-		<td colspan="1" align="right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign|htmlsafe}{$invoice.gross|siLocal_number}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
+		<td colspan="1" align="right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign} {$invoice.gross|siLocal_number}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
     </tr>
     {/if}
 	{if $invoice_number_of_taxes > 1 }
@@ -350,7 +350,7 @@
     	<tr>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}&nbsp;</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    {/if}
 	    
@@ -359,7 +359,7 @@
 	<tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.tax_total}&nbsp;</td>
-		<td colspan="1" align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+		<td colspan="1" align="right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     </tr>
     {/if}
 	{if $invoice_number_of_taxes > 1}
@@ -370,14 +370,14 @@
     <tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right"><b>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}&nbsp;</b></td>
-		<td colspan="1" align="right"><span class="double_underline"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</u></span></td>
+		<td colspan="1" align="right"><span class="double_underline"><u>{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</u></span></td>
     </tr>
     {* tax section - end *}
 {*
 		<tr>
 			<td class="" colspan="2"></td>
 			<td align="right" colspan="3">{$LANG.sub_total}</td>
-			<td align="right" class="">{$preference.pref_currency_sign|htmlsafe}{$invoice.gross|siLocal_number}</td>
+			<td align="right" class="">{$preference.pref_currency_sign} {$invoice.gross|siLocal_number}</td>
 		</tr>
 	
 	
@@ -388,7 +388,7 @@
 		<tr class=''>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    
 	    {/if}
@@ -398,7 +398,7 @@
 	<tr class=''>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.tax_total}</td>
-		<td colspan="1" align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+		<td colspan="1" align="right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     </tr>
 	
 	
@@ -408,7 +408,7 @@
 	<tr class="">
 		<td class="" colspan="2"></td>
 		<td class="" align="right" colspan="3"><b>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}</b></td>
-		<td  class="" align="right"><span class="double_underline" >{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</span></td>
+		<td  class="" align="right"><span class="double_underline" >{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</span></td>
 	</tr>
 *}
 	<tr>

--- a/extras/invoice_grouped/templates/invoices/grouped/template.tpl
+++ b/extras/invoice_grouped/templates/invoices/grouped/template.tpl
@@ -94,15 +94,15 @@
 
 		<tr>
 				<td class="" >{$LANG.total}: </td>
-				<td class="" align="right" colspan="3">{$preference.pref_currency_sign|htmlsafe}{$invoice.total|number_format:2}</td>
+				<td class="" align="right" colspan="3">{$preference.pref_currency_sign} {$invoice.total|number_format:2}</td>
 		</tr>
 		<tr>
 				<td class="">{$LANG.paid}:</td>
-				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign|htmlsafe}{$invoice.paid|number_format:2}</td>
+				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign} {$invoice.paid|number_format:2}</td>
 		</tr>
 		<tr>
 				<td nowrap class="">{$LANG.owing}:</td>
-				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign|htmlsafe}{$invoice.owing|number_format:2}</td>
+				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign} {$invoice.owing|number_format:2}</td>
 		</tr>
 
 	</table>
@@ -248,8 +248,8 @@
 							<tr class="" >
 								<td class="">{$invoiceItem.quantity|siLocal_number_trim}</td>
 								<td class="" colspan="3">{$invoiceItem.product.description|htmlsafe}</td>
-								<td class="" align="right">{$preference.pref_currency_sign}{$invoiceItem.unit_price|siLocal_number}</td>
-								<td class="" align="right">{$preference.pref_currency_sign}{$invoiceItem.gross_total|siLocal_number}</td>
+								<td class="" align="right">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+								<td class="" align="right">{$preference.pref_currency_sign} {$invoiceItem.gross_total|siLocal_number}</td>
 							</tr>
 
 							{if $invoiceItem.description != null}
@@ -266,7 +266,7 @@
 								Subtotal:
 							</td>
 							<td align="right">
-								{$preference.pref_currency_sign|htmlsafe}{subtotal cost=$invoiceItems group=$group.name}
+								{$preference.pref_currency_sign} {subtotal cost=$invoiceItems group=$group.name}
 							</td>
 						</tr>
 						<tr>
@@ -274,7 +274,7 @@
 								Markup {markup_percentage cost=$invoiceItems group=$group.name}%{* {$group.markup|htmlsafe} *}:
 							</td>
 							<td align="right">
-								 {$preference.pref_currency_sign|htmlsafe}{markup cost=$invoiceItems group=$group.name}
+								 {$preference.pref_currency_sign} {markup cost=$invoiceItems group=$group.name}
 							</td>
 						</tr>
 						<tr>
@@ -282,7 +282,7 @@
 								Total:
 							</td>
 							<td align="right">
-								{$preference.pref_currency_sign|htmlsafe}{total cost=$invoiceItems group=$group.name}
+								{$preference.pref_currency_sign} {total cost=$invoiceItems group=$group.name}
 							</td>
 						</tr>
 						<tr>
@@ -316,7 +316,7 @@
 		<tr>
 			<td class="" colspan="2"></td>
 			<td align="right" colspan="3">{$LANG.gross_total}</td>
-			<td align="right" class="">{$preference.pref_currency_sign|htmlsafe}{$invoiceItems.0.gross_total|siLocal_number}</td>
+			<td align="right" class="">{$preference.pref_currency_sign} {$invoiceItems.0.gross_total|siLocal_number}</td>
 		</tr>
 	{/if}
 	
@@ -328,7 +328,7 @@
 		<tr class=''>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    
 	    {/if}
@@ -338,7 +338,7 @@
 	<tr class=''>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.tax_total}</td>
-		<td colspan="1" align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+		<td colspan="1" align="right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     </tr>
 *}	
 	
@@ -346,7 +346,7 @@
 		<td class="" colspan="6" ><br></td>
 	</tr>
 	<tr class="">
-		<th colspan="6" align="middle"><span class="font1 double_underline" >TOTAL {$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</span></td>
+		<th colspan="6" align="middle"><span class="font1 double_underline" >TOTAL {$preference.pref_currency_sign} {$invoice.total|siLocal_number}</span></td>
 	</tr>
 {*
 	<tr>

--- a/templates/default/invoices/delete.tpl
+++ b/templates/default/invoices/delete.tpl
@@ -49,7 +49,7 @@
 	
 	        {if $invoicePaid != 0}
             <span class="welcome">
-				{$preference.pref_inv_wording|htmlsafe} {$invoice.id|htmlsafe} {$LANG.delete_has_payments} {$preference.pref_currency_sign|htmlsafe}{$invoicePaid|htmlsafe} 
+				{$preference.pref_inv_wording|htmlsafe} {$invoice.id|htmlsafe} {$LANG.delete_has_payments} {$preference.pref_currency_sign} {$invoicePaid|htmlsafe} 
     </span>
 				<br />
 				{* LANG_TODO: Add help section here!! *}

--- a/templates/default/invoices/quick_view.tpl
+++ b/templates/default/invoices/quick_view.tpl
@@ -231,8 +231,8 @@
 					<tr>
 							<td class="si_quantity">{$invoiceItem.quantity|siLocal_number_trim}</td>
 							<td class="td_product" colspan="2">{$invoiceItem.product.description|htmlsafe}</td>
-							<td class="si_right">{$preference.pref_currency_sign}{$invoiceItem.unit_price|siLocal_number}</td>
-							<td class="si_right">{$preference.pref_currency_sign}{$invoiceItem.gross_total|siLocal_number}</td>
+							<td class="si_right">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+							<td class="si_right">{$preference.pref_currency_sign} {$invoiceItem.gross_total|siLocal_number}</td>
 					</tr>
 					{if $invoiceItem.attribute != null}
                             <tr class="si_product_attribute">
@@ -243,7 +243,7 @@
                                     {foreach from=$invoiceItem.attribute_json key=k item=v}
                                         <td class="si_product_attribute">
                                             {if $v.type == 'decimal'}
-                                              {$v.name}: {$preference.pref_currency_sign|htmlsafe}{$v.value|siLocal_number} ;
+                                              {$v.name}: {$preference.pref_currency_sign} {$v.value|siLocal_number} ;
                                              {else}
                                                {$v.name}: {$v.value} ;
                                             {/if}
@@ -300,8 +300,8 @@
 					<tr>
 							<td class="si_quantity">{$invoiceItem.quantity|siLocal_number}</td>
 							<td class="td_product" colspan="2">{$invoiceItem.product.description|htmlsafe}</td>
-							<td class="si_right">{$preference.pref_currency_sign}{$invoiceItem.unit_price|siLocal_number}</td>
-							<td class="si_right">{$preference.pref_currency_sign}{$invoiceItem.gross_total|siLocal_number}</td>		
+							<td class="si_right">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+							<td class="si_right">{$preference.pref_currency_sign} {$invoiceItem.gross_total|siLocal_number}</td>		
 					</tr>
 
 					<tr  class="consulting tr_custom" >	
@@ -363,7 +363,7 @@
 		<tr class="tr_tax">
 	        <td colspan="4"></td>
 			<th>{$LANG.sub_total}</th>
-			<td class="si_right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign|htmlsafe}{$invoice.gross|siLocal_number}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
+			<td class="si_right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign} {$invoice.gross|siLocal_number}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
     	</tr>
     {/if}
 	
@@ -377,7 +377,7 @@
 		<tr class="tr_tax">
 	        <td colspan="4"></td>
 			<th>{$invoice.tax_grouped[line].tax_name|htmlsafe}</th>
-			<td class="si_right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td class="si_right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    {/if}
 	    
@@ -386,7 +386,7 @@
 		<tr class="tr_tax">
 	        <td colspan="4"></td>
 			<th>{$LANG.tax_total}</th>
-			<td class="si_right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+			<td class="si_right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     	</tr>
     {/if}
 	{if $invoice_number_of_taxes > 1}
@@ -395,7 +395,7 @@
 		<tr class="tr_total">
 	        <td colspan="4"></td>
 			<th>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}</th>
-			<td class="si_right">{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</td>
+			<td class="si_right">{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</td>
 	    </tr>
     {* tax section - end *}
 	</table>
@@ -418,8 +418,8 @@
 				</tr>
 				<tr>
 					<td>{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</td>
-					<td>{$preference.pref_currency_sign|htmlsafe} {$invoice.paid|siLocal_number}</td>
-					<td>{$preference.pref_currency_sign|htmlsafe} {$invoice.owing|siLocal_number}</td>
+					<td>{$preference.pref_currency_sign} {$invoice.paid|siLocal_number}</td>
+					<td>{$preference.pref_currency_sign} {$invoice.owing|siLocal_number}</td>
 					<td>{$invoice_age|htmlsafe}</td>
 				</tr>
 			</table>
@@ -433,9 +433,9 @@
 					<th>{$LANG.owing}</th>
 				</tr>
 				<tr>
-					<td>{$preference.pref_currency_sign|htmlsafe} {$customerAccount.total|siLocal_number}</td>
-					<td>{$preference.pref_currency_sign|htmlsafe} {$customerAccount.paid|siLocal_number}</td>
-					<td>{$preference.pref_currency_sign|htmlsafe} {$customerAccount.owing|siLocal_number}</td>
+					<td>{$preference.pref_currency_sign} {$customerAccount.total|siLocal_number}</td>
+					<td>{$preference.pref_currency_sign} {$customerAccount.paid|siLocal_number}</td>
+					<td>{$preference.pref_currency_sign} {$customerAccount.owing|siLocal_number}</td>
 				</tr>
 			</table>
 		</div>

--- a/templates/default/payments/print.tpl
+++ b/templates/default/payments/print.tpl
@@ -155,7 +155,7 @@
 		<tr class="" >
 			<td class="">{$payment.id|htmlsafe}</td>
 			<td class="" colspan="3">{$payment.ac_inv_id|htmlsafe}</td>
-			<td class="" align="right">{$preference.pref_currency_sign|htmlsafe}{$payment.ac_amount|siLocal_number}</td>
+			<td class="" align="right">{$preference.pref_currency_sign} {$payment.ac_amount|siLocal_number}</td>
 			<td class="" align="right">{$payment.date|htmlsafe}</td>
 			<td class="" align="right">{$paymentType.pt_description|htmlsafe}</td>
 		</tr>

--- a/templates/default/preferences/details.tpl
+++ b/templates/default/preferences/details.tpl
@@ -11,14 +11,14 @@
 				<a class="cluetip" href="#" rel="index.php?module=documentation&amp;view=view&amp;page=help_inv_pref_description" title="{$LANG.description}">
 				<img src="./images/common/help-small.png" alt="" /> </a>
 			</th>
-			<td>{$preference.pref_description|htmlsafe}</td>
+			<td>{$preference.pref_description}</td>
 		</tr>
 		<tr>
 			<th>Currency sign 
 				<a class="cluetip" href="#" rel="index.php?module=documentation&amp;view=view&amp;page=help_inv_pref_currency_sign" title="{$LANG.currency_sign}">
 				<img src="./images/common/help-small.png" alt="" /> </a>
 			</th>
-			<td>{$preference.pref_currency_sign|htmlsafe}</td>
+			<td>{$preference.pref_currency_sign}</td>
 		</tr>
 		<tr>
 			<th>{$LANG.currency_code}

--- a/templates/invoices/default/template.tpl
+++ b/templates/invoices/default/template.tpl
@@ -62,15 +62,15 @@
 
 		<tr>
 				<td class="" >{$LANG.total}: </td>
-				<td class="" align="right" colspan="3">{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</td>
+				<td class="" align="right" colspan="3">{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</td>
 		</tr>
 		<tr>
 				<td class="">{$LANG.paid}:</td>
-				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign|htmlsafe}{$invoice.paid|siLocal_number}</td>
+				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign} {$invoice.paid|siLocal_number}</td>
 		</tr>
 		<tr>
 				<td nowrap class="">{$LANG.owing}:</td>
-				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign|htmlsafe}{$invoice.owing|siLocal_number}</td>
+				<td class="" align="right" colspan="3" >{$preference.pref_currency_sign} {$invoice.owing|siLocal_number}</td>
 		</tr>
 
 	</table>
@@ -212,8 +212,8 @@
 			<tr class="" >
 				<td class="">{$invoiceItem.quantity|siLocal_number_trim}</td>
 				<td class="" colspan="3">{$invoiceItem.product.description|htmlsafe}</td>
-				<td class="" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.unit_price|siLocal_number}</td>
-				<td class="" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.gross_total|siLocal_number}</td>
+				<td class="" align="right">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+				<td class="" align="right">{$preference.pref_currency_sign} {$invoiceItem.gross_total|siLocal_number}</td>
 			</tr>
 					{if $invoiceItem.attribute != null}
                             <tr class="si_product_attribute">
@@ -225,7 +225,7 @@
                                        {if $v.visible ==true }
                                         <td class="si_product_attribute">
                                             {if $v.type == 'decimal'}
-                                              {$v.name}: {$preference.pref_currency_sign|htmlsafe}{$v.value|siLocal_number};
+                                              {$v.name}: {$preference.pref_currency_sign} {$v.value|siLocal_number};
                                              {else if $v.value !=''}
                                                {$v.name}: {$v.value};
                                             {/if}
@@ -312,8 +312,8 @@
 				<td class=""></td>
 				<td class=""></td>
 				<td class=""></td>
-				<td align="right" class="">{$preference.pref_currency_sign}{$invoiceItem.unit_price|siLocal_number}</td>
-				<td align="right" class="">{$preference.pref_currency_sign}{$invoiceItem.total|siLocal_number}</td>
+				<td align="right" class="">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+				<td align="right" class="">{$preference.pref_currency_sign} {$invoiceItem.total|siLocal_number}</td>
 			</tr>
 			{/foreach}
 	{/if}
@@ -357,7 +357,7 @@
 	<tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.sub_total}&nbsp;</td>
-		<td colspan="1" align="right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign|htmlsafe}{$invoice.gross|siLocal_number}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
+		<td colspan="1" align="right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign} {$invoice.gross|siLocal_number}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
     </tr>
     {/if}
 	{if $invoice_number_of_taxes > 1 }
@@ -371,7 +371,7 @@
     	<tr>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}&nbsp;</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    {/if}
 	    
@@ -380,7 +380,7 @@
 	<tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.tax_total}&nbsp;</td>
-		<td colspan="1" align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+		<td colspan="1" align="right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     </tr>
     {/if}
 	{if $invoice_number_of_taxes > 1}
@@ -391,14 +391,14 @@
     <tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right"><b>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}&nbsp;</b></td>
-		<td colspan="1" align="right"><span class="double_underline"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</u></span></td>
+		<td colspan="1" align="right"><span class="double_underline"><u>{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</u></span></td>
     </tr>
     {* tax section - end *}
 {*
 		<tr>
 			<td class="" colspan="2"></td>
 			<td align="right" colspan="3">{$LANG.sub_total}</td>
-			<td align="right" class="">{$preference.pref_currency_sign|htmlsafe}{$invoice.gross|siLocal_number}</td>
+			<td align="right" class="">{$preference.pref_currency_sign} {$invoice.gross|siLocal_number}</td>
 		</tr>
 	
 	
@@ -409,7 +409,7 @@
 		<tr class=''>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    
 	    {/if}
@@ -419,7 +419,7 @@
 	<tr class=''>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.tax_total}</td>
-		<td colspan="1" align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+		<td colspan="1" align="right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     </tr>
 	
 	
@@ -429,7 +429,7 @@
 	<tr class="">
 		<td class="" colspan="2"></td>
 		<td class="" align="right" colspan="3"><b>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}</b></td>
-		<td  class="" align="right"><span class="double_underline" >{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</span></td>
+		<td  class="" align="right"><span class="double_underline" >{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</span></td>
 	</tr>
 *}
 	<tr>

--- a/templates/invoices/export/consulting.tpl
+++ b/templates/invoices/export/consulting.tpl
@@ -54,8 +54,8 @@
 			<tr class="tbl1-left tbl1-right tbl1-bottom">
 				<td class="tbl1-left tbl1-bottom" ></td>
 				<td colspan="3" class="tbl1-bottom"></td>
-				<td class="tbl1-bottom">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.unit_price|siLocal_number}</td>
-				<td class="tbl1-right tbl1-bottom" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.total|siLocal_number}</td>
+				<td class="tbl1-bottom">{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+				<td class="tbl1-right tbl1-bottom" align="right">{$preference.pref_currency_sign} {$invoiceItem.total|siLocal_number}</td>
 			</tr>
 	
 	{/foreach}
@@ -80,5 +80,5 @@
 		<tr>
 			<td colspan="3"></td>
 			<td align="right" colspan="2">{$LANG.gross_total}</td>
-			<td align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice_gross_total|siLocal_number}</td>
+			<td align="right">{$preference.pref_currency_sign} {$invoice_gross_total|siLocal_number}</td>
 		</tr>	

--- a/templates/invoices/export/itemised.tpl
+++ b/templates/invoices/export/itemised.tpl
@@ -11,8 +11,8 @@
 			<tr>
 				<td>{$invoiceItem.quantity|siLocal_number_trim}</td>
 				<td colspan="3">{$invoiceItem.product.description|htmlsafe}</td>
-				<td>{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.unit_price|siLocal_number}</td>
-				<td align="right">{$preference.pref_currency_sign|htmlsafe}{$invoiceItem.gross_total|siLocal_number}</td>
+				<td>{$preference.pref_currency_sign} {$invoiceItem.unit_price|siLocal_number}</td>
+				<td align="right">{$preference.pref_currency_sign} {$invoiceItem.gross_total|siLocal_number}</td>
 			</tr>
 			{if $invoiceItem.description != null}
 				<tr >

--- a/templates/invoices/export/template.tpl
+++ b/templates/invoices/export/template.tpl
@@ -298,7 +298,7 @@
 	<tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.sub_total}&nbsp;</td>
-		<td colspan="1" align="right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign|htmlsafe}{$invoice.gross|siLocal_number|htmlsafe}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
+		<td colspan="1" align="right">{if $invoice_number_of_taxes > 1}<u>{/if}{$preference.pref_currency_sign} {$invoice.gross|siLocal_number|htmlsafe}{if $invoice_number_of_taxes > 1}</u>{/if}</td>
     </tr>
     {/if}
 	{if $invoice_number_of_taxes > 1 }
@@ -312,7 +312,7 @@
     	<tr>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}&nbsp;</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number|htmlsafe}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number|htmlsafe}</td>
 	    </tr>
 	    {/if}
 	    
@@ -321,7 +321,7 @@
 	<tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right">{$LANG.tax_total}&nbsp;</td>
-		<td colspan="1" align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|siLocal_number}</u></td>
+		<td colspan="1" align="right"><u>{$preference.pref_currency_sign} {$invoice.total_tax|siLocal_number}</u></td>
     </tr>
     {/if}
 	{if $invoice_number_of_taxes > 1}
@@ -332,7 +332,7 @@
     <tr>
         <td colspan="2"></td>
 		<td colspan="3" align="right"><b>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}&nbsp;</b></td>
-		<td colspan="1" align="right"><span class="double_underline">{$preference.pref_currency_sign|htmlsafe}{$invoice.total|siLocal_number}</span></td>
+		<td colspan="1" align="right"><span class="double_underline">{$preference.pref_currency_sign} {$invoice.total|siLocal_number}</span></td>
     </tr>
     {* tax section - end *}
 
@@ -344,7 +344,7 @@
     	<tr class='details_screen'>
 	        <td colspan="2"></td>
 			<td colspan="3" align="right">{$invoice.tax_grouped[line].tax_name|htmlsafe}</td>
-			<td colspan="1" align="right">{$preference.pref_currency_sign|htmlsafe}{$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
+			<td colspan="1" align="right">{$preference.pref_currency_sign} {$invoice.tax_grouped[line].tax_amount|siLocal_number}</td>
 	    </tr>
 	    
 	    {/if}
@@ -355,7 +355,7 @@
 	<tr >
 		<td colspan="3"></td>
 		<td align="right" colspan="2">{$LANG.tax_total}</td>
-		<td align="right" >{$preference.pref_currency_sign|htmlsafe}{$invoice.total_tax|number_format:2}</td>
+		<td align="right" >{$preference.pref_currency_sign} {$invoice.total_tax|number_format:2}</td>
 	</tr>
 	<tr >
 		<td colspan="6" ><br /></td>
@@ -363,7 +363,7 @@
 	<tr >
 		<td colspan="3"></td>
 		<td align="right" colspan="2"><b>{$preference.pref_inv_wording|htmlsafe} {$LANG.amount}</b></td>
-		<td  align="right"><u>{$preference.pref_currency_sign|htmlsafe}{$invoice.total|number_format:2}</u></td>
+		<td  align="right"><u>{$preference.pref_currency_sign} {$invoice.total|number_format:2}</u></td>
 	</tr>
     *}
 	<tr>


### PR DESCRIPTION
...20A8

The new Unicode for Rupee Symbol is &#8377; - U+20B9 and is available only in later browsers
