### PR TITLE
si_log now gets populated and obeys system_defaults setting

### DIFF
--- a/modules/reports/database_log.php
+++ b/modules/reports/database_log.php
@@ -16,10 +16,12 @@ $smarty -> assign('active_tab', '#home');
 	$sql = "SELECT l.*, u.email
 	FROM
 	".TB_PREFIX."log l INNER JOIN 
-	".TB_PREFIX."user u ON (u.id = l.userid)
-	WHERE l.timestamp BETWEEN :start AND :end ORDER BY l.timestamp";
+	".TB_PREFIX."user u ON (u.id = l.userid AND u.domain_id = l.domain_id)
+	WHERE l.domain_id = :domain_id 
+	  AND l.timestamp BETWEEN :start AND :end 
+	ORDER BY l.timestamp";
 	
-	$sth = dbQuery($sql, ':start', $startdate, ':end', $enddate);
+	$sth = dbQuery($sql, ':start', $startdate, ':end', $enddate, ':domain_id', $auth_session->domain_id);
 	$sqls = null;
 	$sqls = $sth->fetchAll();
 	


### PR DESCRIPTION
In PDO mode, only the PDO template query gets saved without the parameters
The files si.log and php.log get populated as well
Discards SHW TABLES LIKE ... sql constructs from the log
Multi Domain fixes
