### PR TITLE
Issue #160

### DIFF
--- a/library/smarty/Smarty_Compiler.class.php
+++ b/library/smarty/Smarty_Compiler.class.php
@@ -262,12 +262,13 @@ class Smarty_Compiler extends Smarty {
         reset($this->_folded_blocks);
 
         /* replace special blocks by "{php}" */
-        $source_content = preg_replace_callback($search, create_function ('$matches', "return '"
-                                       . $this->_quote_replace($this->left_delimiter) . 'php'
-                                       . "' . str_repeat(\"\n\", substr_count('\$matches[1]', \"\n\")) .'"
-                                       . $this->_quote_replace($this->right_delimiter)
-                                       . "';")
-                                       , $source_content);
+        $source_content = preg_replace_callback($search, create_function ('$matches', "return '" 
+                                       . $this->_quote_replace($this->left_delimiter) . 'php' 
+                                       . "' . str_repeat(\"\n\", substr_count('\$matches[1]', \"\n\")) .'" 
+                                       . $this->_quote_replace($this->right_delimiter) 
+                                       . "';") 
+                                       , $source_content); 
+
 
         /* Gather all template tags. */
         preg_match_all("~{$ldq}\s*(.*?)\s*{$rdq}~s", $source_content, $_match);


### PR DESCRIPTION
Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /library/smarty/Smarty_Compiler.class.php on line 270

Screenshot: http://i.imm.io/1n1TR.jpeg
