### PR TITLE
fix test for writable tmp components.

### DIFF
--- a/include/init.php
+++ b/include/init.php
@@ -46,6 +46,11 @@ include_once('./include/functions.php');
 
 //ob_start('addCSRFProtection');
 
+if (!is_writable('./tmp')) {
+    
+   simpleInvoicesError('notWriteable','directory','./tmp');
+}
+
 /*
  * log file - start
  */


### PR DESCRIPTION
This change prevent a blank screen during initial installation. 
In my case apache has different user id then the source files, so the permissions on the higher directory mattered.
