### PR TITLE
invoices not listed

### DIFF
--- a/include/class/invoice.php
+++ b/include/class/invoice.php
@@ -416,7 +416,7 @@ class invoice {
                 WHERE iv.domain_id = :domain_id
 					$where
                 GROUP BY
-                    iv.id
+                    iv.id, index_id, biller, customer, date, type_id, preference, status, index_name
 				$sql_having
                 ORDER BY
 					$sort $dir


### PR DESCRIPTION
Cause: 
Not list invoices after add.

MySQL_ERRO:
#1055 - 'DATA_BASE_NAME.iv.index_id' isn't in GROUP BY

Solution:
add this fields in the GROUP BY (iv.id, index_id, biller, customer, date, type_id, preference, status, index_name)
