### PR TITLE
system_defaults not update

### DIFF
--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -1242,11 +1242,11 @@ function updateDefault($name,$value,$extension_name="core") {
 	$sql = "INSERT INTO 
 		`".TB_PREFIX."system_defaults`
 		(
-			`name`, `value`, domain_id, extension_id
+			`name`, `value`, domain_id, extension_id, new_id
 		)
 		VALUES 
 		(
-			:name, :value, :domain_id, :extension_id
+			:name, :value, :domain_id, :extension_id, (SELECT b.new_id FROM `".TB_PREFIX."system_defaults` AS b WHERE b.name = :name AND b.domain_id = :domain_id)
 		) 
 		ON DUPLICATE KEY UPDATE
 			`value` =  :value";


### PR DESCRIPTION
Cause: 
After updating any field system_defaults the change was not displayed.

MySQL_ERRO:
#1364 - Field 'new_id' doesn't have a default value

Solution:
Retrieve the value of the new_id field using a select through the field to be changed and the domain ID.
