### PR TITLE
Added option "local.datelength" to let users set the length of date

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -26,6 +26,8 @@ export.pdf.bottommargin 			= 15
 
 local.locale	    				= en_GB
 local.precision		    			= 2
+; datelength can be any of the Zend_Date lenghts - full, long, medium, short
+local.datelength                               = short
 
 email.host 				            = localhost
 email.smtp_auth			    		= false

--- a/include/class/siLocal.php
+++ b/include/class/siLocal.php
@@ -62,7 +62,7 @@ class siLocal
 		global $config;
 		
 		$locale == "" ? $locale = new Zend_Locale($config->local->locale) : $locale = $locale;
-		$length == "" ? $length = "medium" : $lenght = $length;
+		$length == "" ? $length = $config->local->datelength : $length = $length;	
 		/*
 		 * Length can be any of the Zend_Date lenghts - FULL, LONG, MEDIUM, SHORT
 		 */


### PR DESCRIPTION
In the forums I found that some people (like me) had trouble getting simpleinvoices to show ISO date format (YYYY-MM-DD). This tiny patch lets us do just that by setting local.locale to sv_SE (Swedish) and local.datelength = short.