### PR TITLE
Bug fix

### DIFF
--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -2867,7 +2867,7 @@ function runPatches() {
 
 	$smarty_datas=array();	
 
-	if(count($rows) == 1) {
+	if(count($rows) >= 1) {
 
 		if ($db_server == 'pgsql') {
 			// Yay!  Transactional DDL


### PR DESCRIPTION
If `runPatches` is called after some patches have been installed it will act as if no patches have been installed. With this simple change it should run as expected every time.