### PR TITLE
Update Tabler CSS theme to azure variant

### DIFF
--- a/templates/default/header.blade.php
+++ b/templates/default/header.blade.php
@@ -22,7 +22,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="https://preview.tabler.io/dist/css/tabler.min.css" />
+    <link rel="stylesheet" href="https://preview.tabler.io/dist/css/tabler-azure.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css" />
     <link rel="stylesheet" href="./templates/default/css/si-tabler.css" />
     <link rel="stylesheet" href="./templates/default/css/print.css" media="print" />

--- a/templates/default/payments/print.blade.php
+++ b/templates/default/payments/print.blade.php
@@ -7,7 +7,7 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-	<link rel="stylesheet" href="https://preview.tabler.io/dist/css/tabler.min.css" />
+	<link rel="stylesheet" href="https://preview.tabler.io/dist/css/tabler-azure.min.css" />
 	<style type="text/css" media="all">
 		body { background: #fff; color: #1e293b; font-size: 14px; padding: 2rem; }
 		@media print { body { padding: 0; } .no-print { display: none !important; } }


### PR DESCRIPTION
## Summary
Updated the Tabler CSS framework stylesheet from the default theme to the azure color variant across the application templates.

## Changes
- Updated Tabler CSS stylesheet reference in `templates/default/header.blade.php` from `tabler.min.css` to `tabler-azure.min.css`
- Updated Tabler CSS stylesheet reference in `templates/default/payments/print.blade.php` from `tabler.min.css` to `tabler-azure.min.css`

## Details
Both template files now use the azure-themed variant of the Tabler CSS framework, which provides a cohesive blue color scheme throughout the application UI and print layouts.

https://claude.ai/code/session_01PEWTdtkTXPw9AqjjhPoqej