### PR TITLE
Add calendar icons to date input fields across templates

### DIFF
--- a/templates/default/cron/add.blade.php
+++ b/templates/default/cron/add.blade.php
@@ -36,11 +36,17 @@
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['start_date'] ?? '' }}</label>
-			<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date" value='{{ date('Y-m-d', strtotime('+1 day')) }}' />
+			<div class="input-group">
+				<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+				<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date" value='{{ date('Y-m-d', strtotime('+1 day')) }}' />
+			</div>
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['end_date'] ?? '' }}</label>
-			<input type="text" class="form-control date-picker" size="10" name="end_date" id="date" value='' />
+			<div class="input-group">
+				<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+				<input type="text" class="form-control date-picker" size="10" name="end_date" id="date" value='' />
+			</div>
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['recur_each'] ?? '' }}</label>

--- a/templates/default/cron/edit.blade.php
+++ b/templates/default/cron/edit.blade.php
@@ -37,11 +37,17 @@
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['start_date'] ?? '' }}</label>
-			<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date" value='{{ $cron['start_date'] ?? '' }}' />
+			<div class="input-group">
+				<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+				<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date" value='{{ $cron['start_date'] ?? '' }}' />
+			</div>
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['end_date'] ?? '' }}</label>
-			<input type="text" class="form-control date-picker" size="10" name="end_date" id="date" value='{{ $cron['end_date'] ?? '' }}' />
+			<div class="input-group">
+				<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+				<input type="text" class="form-control date-picker" size="10" name="end_date" id="date" value='{{ $cron['end_date'] ?? '' }}' />
+			</div>
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['recur_each'] ?? '' }}</label>

--- a/templates/default/inventory/add.blade.php
+++ b/templates/default/inventory/add.blade.php
@@ -42,7 +42,10 @@
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['date_upper'] ?? '' }}</label>
-			<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="date" id="date" value='{{ date('Y-m-d') }}' />
+			<div class="input-group">
+				<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+				<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="date" id="date" value='{{ date('Y-m-d') }}' />
+			</div>
 		</div>
 		<div class="mb-3">
 			<label class="form-label">{{ $LANG['cost'] ?? '' }}</label>

--- a/templates/default/inventory/edit.blade.php
+++ b/templates/default/inventory/edit.blade.php
@@ -32,7 +32,10 @@
 			<tr>
 				<th>{{ $LANG['date_upper'] ?? '' }}</th>
 				<td>
-					<input type="text" name="date" id="date" size="10" value="{{ $inventory['date'] ?? '' }}" class="form-control validate[required,custom[date],length[0,10]] date-picker" />
+					<div class="input-group">
+						<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+						<input type="text" name="date" id="date" size="10" value="{{ $inventory['date'] ?? '' }}" class="form-control validate[required,custom[date],length[0,10]] date-picker" />
+					</div>
 				</td>
 			</tr>
 			<tr>

--- a/templates/default/invoices/details.blade.php
+++ b/templates/default/invoices/details.blade.php
@@ -24,11 +24,14 @@
 			</div>
 			<div class="col-md-2">
 				<label class="form-label">{{ $LANG['date_formatted'] ?? '' }}</label>
-				@if($invoice['id'] == null)
-					<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" name="date" id="date1" value="{{ date('Y-m-d') }}" />
-				@else
-					<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" name="date" id="date1" value="{{ $invoice['calc_date'] ?? '' }}" />
-				@endif
+				<div class="input-group">
+					<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+					@if($invoice['id'] == null)
+						<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" name="date" id="date1" value="{{ date('Y-m-d') }}" />
+					@else
+						<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" name="date" id="date1" value="{{ $invoice['calc_date'] ?? '' }}" />
+					@endif
+				</div>
 			</div>
 			<div class="col-md-4">
 				<label class="form-label">{{ $LANG['biller'] ?? '' }}</label>

--- a/templates/default/invoices/header.blade.php
+++ b/templates/default/invoices/header.blade.php
@@ -50,12 +50,15 @@
 		</div>
 		<div class="col-md-3">
 			<label class="form-label">{{ $LANG['date_formatted'] ?? '' }}</label>
-			<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" name="date" id="date1"
-				@if(get('date'))
-					value="{{ get('date') }}"
-				@else
-					value="{{ date('Y-m-d') }}"
-				@endif
-			/>
+			<div class="input-group">
+				<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+				<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" name="date" id="date1"
+					@if(get('date'))
+						value="{{ get('date') }}"
+					@else
+						value="{{ date('Y-m-d') }}"
+					@endif
+				/>
+			</div>
 		</div>
 	</div>

--- a/templates/default/payments/process.blade.php
+++ b/templates/default/payments/process.blade.php
@@ -33,7 +33,10 @@
 			</div>
 			<div class="mb-3">
 				<label class="form-label">{{ $LANG['date_formatted'] ?? '' }}</label>
-				<input type="text" class="form-control date-picker" name="ac_date" id="date1" value="{{ $today ?? '' }}" />
+				<div class="input-group">
+					<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+					<input type="text" class="form-control date-picker" name="ac_date" id="date1" value="{{ $today ?? '' }}" />
+				</div>
 			</div>
 		@endif
 
@@ -55,7 +58,10 @@
 			</div>
 			<div class="mb-3">
 				<label class="form-label">{{ $LANG['date_formatted'] ?? '' }}</label>
-				<input type="text" class="form-control date-picker" name="ac_date" id="date1" value="{{ $today ?? '' }}" />
+				<div class="input-group">
+					<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+					<input type="text" class="form-control date-picker" name="ac_date" id="date1" value="{{ $today ?? '' }}" />
+				</div>
 			</div>
 		@endif
 

--- a/templates/default/reports/report_invoice_profit.blade.php
+++ b/templates/default/reports/report_invoice_profit.blade.php
@@ -4,7 +4,10 @@
 <table class="table table-vcenter" align="center">
     <tr>
         <td wrap="nowrap">{{ $LANG['start_date'] ?? 'Start date (YYYY-MM-DD)' }}
-                <input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date1" value="{{ $start_date ?? '' }}" />
+                <div class="input-group">
+                    <span class="input-group-text"><i class="ti ti-calendar"></i></span>
+                    <input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date1" value="{{ $start_date ?? '' }}" />
+                </div>
          </td>
         <td>
             &nbsp;
@@ -14,7 +17,10 @@
             &nbsp;
         </td>
         <td wrap="nowrap">{{ $LANG['end_date'] ?? 'End date (YYYY-MM-DD)' }}
-                <input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="end_date" id="date1" value="{{ $end_date ?? '' }}" />
+                <div class="input-group">
+                    <span class="input-group-text"><i class="ti ti-calendar"></i></span>
+                    <input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="end_date" id="date1" value="{{ $end_date ?? '' }}" />
+                </div>
             </td>
     </tr>
 </table>

--- a/templates/default/statement/index.blade.php
+++ b/templates/default/statement/index.blade.php
@@ -50,7 +50,10 @@
 				{{ $LANG['start_date'] ?? '' }}
 			</td>
 			<td>
-				<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date1" value="{{ $start_date ?? '' }}" />
+				<div class="input-group">
+					<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+					<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="start_date" id="date1" value="{{ $start_date ?? '' }}" />
+				</div>
 			 </td>
 		</tr>
 		<tr>
@@ -58,7 +61,10 @@
 				{{ $LANG['end_date'] ?? '' }}
 			</td>
 			<td>
-				<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="end_date" id="date1" value="{{ $end_date ?? '' }}" />
+				<div class="input-group">
+					<span class="input-group-text"><i class="ti ti-calendar"></i></span>
+					<input type="text" class="form-control validate[required,custom[date],length[0,10]] date-picker" size="10" name="end_date" id="date1" value="{{ $end_date ?? '' }}" />
+				</div>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Summary
This PR enhances the user experience by adding calendar icons to all date input fields throughout the application. Each date picker input is now wrapped in a Bootstrap input group with a calendar icon from the Tabler icon set.

## Key Changes
- **Invoices**: Added calendar icons to date fields in header and details templates
- **Cron Jobs**: Added calendar icons to start_date and end_date fields in both add and edit forms
- **Payments**: Added calendar icons to date fields in the payment processing template
- **Reports**: Added calendar icons to start_date and end_date fields in the invoice profit report
- **Statements**: Added calendar icons to start_date and end_date fields in the statement index
- **Inventory**: Added calendar icons to date fields in both add and edit forms

## Implementation Details
- All date inputs are now wrapped in a `<div class="input-group">` container
- Each input group includes a `<span class="input-group-text">` with a calendar icon: `<i class="ti ti-calendar"></i>`
- The date input fields retain all existing validation classes and functionality
- This change provides consistent visual feedback across the application for date selection fields

https://claude.ai/code/session_01C1HutzoRiDigSdcx7qWekF