### PR TITLE
Add settings icon to action dropdown buttons across modules

### DIFF
--- a/modules/billers/xml.php
+++ b/modules/billers/xml.php
@@ -100,7 +100,7 @@ $xml .= "<total>$count</total>";
 foreach ($billers as $row) {
 	$name_esc = htmlspecialchars($row['name']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=billers&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=billers&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/billers/xml.php
+++ b/modules/billers/xml.php
@@ -100,7 +100,7 @@ $xml .= "<total>$count</total>";
 foreach ($billers as $row) {
 	$name_esc = htmlspecialchars($row['name']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=billers&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=billers&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/cron/xml.php
+++ b/modules/cron/xml.php
@@ -29,7 +29,7 @@ $xml ="";
 		$row['email_customer_nice'] = $row['email_customer']==1?$LANG['yes']:$LANG['no'];
 		$name_esc = htmlspecialchars($row['name'] ?? $row['index_name'] ?? (string)$row['id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=cron&amp;view=view&amp;id='.$row['id'].'"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=cron&amp;view=edit&amp;id='.$row['id'].'"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/cron/xml.php
+++ b/modules/cron/xml.php
@@ -29,7 +29,7 @@ $xml ="";
 		$row['email_customer_nice'] = $row['email_customer']==1?$LANG['yes']:$LANG['no'];
 		$name_esc = htmlspecialchars($row['name'] ?? $row['index_name'] ?? (string)$row['id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=cron&amp;view=view&amp;id='.$row['id'].'"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=cron&amp;view=edit&amp;id='.$row['id'].'"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/custom_fields/xml.php
+++ b/modules/custom_fields/xml.php
@@ -85,7 +85,7 @@ if (in_array($sort, $validFields)) {
 	foreach ($cfs as $row) {
 		$label_esc = htmlspecialchars($row['field_name_nice'] ?? $row['cf_custom_label'] ?? (string)$row['cf_id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=custom_fields&amp;view=details&amp;id='.$row['cf_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$label_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=custom_fields&amp;view=details&amp;id='.$row['cf_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$label_esc.'</a>';

--- a/modules/custom_fields/xml.php
+++ b/modules/custom_fields/xml.php
@@ -85,7 +85,7 @@ if (in_array($sort, $validFields)) {
 	foreach ($cfs as $row) {
 		$label_esc = htmlspecialchars($row['field_name_nice'] ?? $row['cf_custom_label'] ?? (string)$row['cf_id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=custom_fields&amp;view=details&amp;id='.$row['cf_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$label_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=custom_fields&amp;view=details&amp;id='.$row['cf_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$label_esc.'</a>';

--- a/modules/customers/xml.php
+++ b/modules/customers/xml.php
@@ -116,7 +116,7 @@ $count = $sth_count_rows->rowCount();
 	foreach ($customers as $row) {
 		$name_esc = htmlspecialchars($row['name']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=customers&amp;view=details&amp;id='.$row['CID'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=customers&amp;view=details&amp;id='.$row['CID'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/customers/xml.php
+++ b/modules/customers/xml.php
@@ -116,7 +116,7 @@ $count = $sth_count_rows->rowCount();
 	foreach ($customers as $row) {
 		$name_esc = htmlspecialchars($row['name']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=customers&amp;view=details&amp;id='.$row['CID'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=customers&amp;view=details&amp;id='.$row['CID'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/inventory/xml.php
+++ b/modules/inventory/xml.php
@@ -25,7 +25,7 @@ $count = $sth_count_rows;
 	foreach ($inventory_all as $row) {
 		$name_esc = htmlspecialchars($row['description'] ?? $row['name'] ?? (string)$row['id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=inventory&amp;view=view&amp;id='.$row['id'].'"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=inventory&amp;view=edit&amp;id='.$row['id'].'"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/inventory/xml.php
+++ b/modules/inventory/xml.php
@@ -25,7 +25,7 @@ $count = $sth_count_rows;
 	foreach ($inventory_all as $row) {
 		$name_esc = htmlspecialchars($row['description'] ?? $row['name'] ?? (string)$row['id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=inventory&amp;view=view&amp;id='.$row['id'].'"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=inventory&amp;view=edit&amp;id='.$row['id'].'"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/invoices/xml.php
+++ b/modules/invoices/xml.php
@@ -54,7 +54,7 @@ $xml ="";
 		$xml .= "<row id='".$row['id']."'>";
 		$inv_label = htmlspecialchars($row['preference'] . ' ' . $row['index_id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=invoices&amp;view=quick_view&amp;id='.$row['id'].'"><i class="ti ti-eye me-2"></i>'.$LANG['quick_view_tooltip'].' '.$inv_label.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=invoices&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-edit me-2"></i>'.$LANG['edit_view_tooltip'].' '.$inv_label.'</a>';

--- a/modules/invoices/xml.php
+++ b/modules/invoices/xml.php
@@ -54,7 +54,7 @@ $xml ="";
 		$xml .= "<row id='".$row['id']."'>";
 		$inv_label = htmlspecialchars($row['preference'] . ' ' . $row['index_id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=invoices&amp;view=quick_view&amp;id='.$row['id'].'"><i class="ti ti-eye me-2"></i>'.$LANG['quick_view_tooltip'].' '.$inv_label.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=invoices&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-edit me-2"></i>'.$LANG['edit_view_tooltip'].' '.$inv_label.'</a>';

--- a/modules/payment_types/xml.php
+++ b/modules/payment_types/xml.php
@@ -95,7 +95,7 @@ $xml .= "<total>$count</total>";
 foreach ($payment_types as $row) {
 	$desc_esc = htmlspecialchars($row['pt_description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=payment_types&amp;view=details&amp;id='.$row['pt_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=payment_types&amp;view=details&amp;id='.$row['pt_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/payment_types/xml.php
+++ b/modules/payment_types/xml.php
@@ -95,7 +95,7 @@ $xml .= "<total>$count</total>";
 foreach ($payment_types as $row) {
 	$desc_esc = htmlspecialchars($row['pt_description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=payment_types&amp;view=details&amp;id='.$row['pt_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=payment_types&amp;view=details&amp;id='.$row['pt_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/payments/xml.php
+++ b/modules/payments/xml.php
@@ -148,7 +148,7 @@ $count = $resultCount[0];
 	foreach ($payments as $row) {
 		$label_esc = htmlspecialchars($row['index_name'] ?? (string)$row['id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=payments&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$label_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=payments&amp;view=print&amp;id='.$row['id'].'"><i class="ti ti-printer me-2"></i>'.$LANG['print_preview_tooltip'].' '.$label_esc.'</a>';

--- a/modules/payments/xml.php
+++ b/modules/payments/xml.php
@@ -148,7 +148,7 @@ $count = $resultCount[0];
 	foreach ($payments as $row) {
 		$label_esc = htmlspecialchars($row['index_name'] ?? (string)$row['id']);
 		$action  = '<div class="dropdown">';
-		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+		$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 		$action .= '<div class="dropdown-menu dropdown-menu-end">';
 		$action .= '<a class="dropdown-item" href="index.php?module=payments&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$label_esc.'</a>';
 		$action .= '<a class="dropdown-item" href="index.php?module=payments&amp;view=print&amp;id='.$row['id'].'"><i class="ti ti-printer me-2"></i>'.$LANG['print_preview_tooltip'].' '.$label_esc.'</a>';

--- a/modules/preferences/xml.php
+++ b/modules/preferences/xml.php
@@ -95,7 +95,7 @@ $xml .= "<total>$count</total>";
 foreach ($preferences as $row) {
 	$desc_esc = htmlspecialchars($row['pref_description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=preferences&amp;view=details&amp;id='.$row['pref_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=preferences&amp;view=details&amp;id='.$row['pref_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/preferences/xml.php
+++ b/modules/preferences/xml.php
@@ -95,7 +95,7 @@ $xml .= "<total>$count</total>";
 foreach ($preferences as $row) {
 	$desc_esc = htmlspecialchars($row['pref_description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=preferences&amp;view=details&amp;id='.$row['pref_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=preferences&amp;view=details&amp;id='.$row['pref_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/product_attribute/xml.php
+++ b/modules/product_attribute/xml.php
@@ -92,7 +92,7 @@ foreach ($customers as $row) {
 
 	$name_esc = htmlspecialchars($row['name'] ?? (string)$row['id']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_attribute&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_attribute&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/product_attribute/xml.php
+++ b/modules/product_attribute/xml.php
@@ -92,7 +92,7 @@ foreach ($customers as $row) {
 
 	$name_esc = htmlspecialchars($row['name'] ?? (string)$row['id']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_attribute&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$name_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_attribute&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$name_esc.'</a>';

--- a/modules/product_value/xml.php
+++ b/modules/product_value/xml.php
@@ -91,7 +91,7 @@ foreach ($customers as $row) {
 
 	$label_esc = htmlspecialchars(($row['name'] ?? '').': '.($row['value'] ?? (string)$row['id']));
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_value&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$label_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_value&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$label_esc.'</a>';

--- a/modules/product_value/xml.php
+++ b/modules/product_value/xml.php
@@ -91,7 +91,7 @@ foreach ($customers as $row) {
 
 	$label_esc = htmlspecialchars(($row['name'] ?? '').': '.($row['value'] ?? (string)$row['id']));
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_value&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$label_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=product_value&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$label_esc.'</a>';

--- a/modules/products/xml.php
+++ b/modules/products/xml.php
@@ -29,7 +29,7 @@ $xml .= "<total>$count</total>";
 foreach ($products_all as $row) {
 	$desc_esc = htmlspecialchars($row['description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=products&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=products&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/products/xml.php
+++ b/modules/products/xml.php
@@ -29,7 +29,7 @@ $xml .= "<total>$count</total>";
 foreach ($products_all as $row) {
 	$desc_esc = htmlspecialchars($row['description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=products&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=products&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/tax_rates/xml.php
+++ b/modules/tax_rates/xml.php
@@ -98,7 +98,7 @@ $xml .= "<total>$count</total>";
 foreach ($tax as $row) {
 	$desc_esc = htmlspecialchars($row['tax_description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=tax_rates&amp;view=details&amp;id='.$row['tax_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=tax_rates&amp;view=details&amp;id='.$row['tax_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/tax_rates/xml.php
+++ b/modules/tax_rates/xml.php
@@ -98,7 +98,7 @@ $xml .= "<total>$count</total>";
 foreach ($tax as $row) {
 	$desc_esc = htmlspecialchars($row['tax_description']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=tax_rates&amp;view=details&amp;id='.$row['tax_id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$desc_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=tax_rates&amp;view=details&amp;id='.$row['tax_id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$desc_esc.'</a>';

--- a/modules/user/xml.php
+++ b/modules/user/xml.php
@@ -101,7 +101,7 @@ $xml .= "<total>$count</total>";
 foreach ($user as $row) {
 	$display_esc = htmlspecialchars(!empty($row['name']) ? $row['name'] : $row['email']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-settings me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=user&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$display_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=user&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$display_esc.'</a>';

--- a/modules/user/xml.php
+++ b/modules/user/xml.php
@@ -101,7 +101,7 @@ $xml .= "<total>$count</total>";
 foreach ($user as $row) {
 	$display_esc = htmlspecialchars(!empty($row['name']) ? $row['name'] : $row['email']);
 	$action  = '<div class="dropdown">';
-	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline">'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
+	$action .= '<a class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-sm-inline"><i class="ti ti-bolt me-1"></i>'.$LANG['actions'].'</span><span class="d-sm-none"><i class="ti ti-dots-vertical" aria-hidden="true"></i></span></a>';
 	$action .= '<div class="dropdown-menu dropdown-menu-end">';
 	$action .= '<a class="dropdown-item" href="index.php?module=user&amp;view=details&amp;id='.$row['id'].'&amp;action=view"><i class="ti ti-eye me-2"></i>'.$LANG['view'].' '.$display_esc.'</a>';
 	$action .= '<a class="dropdown-item" href="index.php?module=user&amp;view=details&amp;id='.$row['id'].'&amp;action=edit"><i class="ti ti-edit me-2"></i>'.$LANG['edit'].' '.$display_esc.'</a>';

--- a/templates/default/menu.blade.php
+++ b/templates/default/menu.blade.php
@@ -175,7 +175,7 @@
                     {{-- Settings --}}
                     <li class="nav-item dropdown @if(in_array($module ?? '', ['options','system_defaults','custom_fields','tax_rates','preferences','payment_types'])) active @endif">
                         <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="outside" role="button" aria-expanded="false">
-                            <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="ti ti-settings"></i></span>
+                            <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="ti ti-adjustments-horizontal"></i></span>
                             <span class="nav-link-title">{{ $LANG['settings'] ?? 'Settings' }}</span>
                         </a>
                         <div class="dropdown-menu dropdown-menu-lg-end">


### PR DESCRIPTION
## Summary
This PR adds a settings/adjustments icon to the action dropdown toggle buttons across multiple modules for improved visual consistency and UX. The icon appears on desktop/larger screens alongside the "Actions" text label.

## Key Changes
- Added `<i class="ti ti-settings me-1"></i>` icon before the "Actions" text in dropdown toggle buttons across 16 modules:
  - billers
  - cron
  - custom_fields
  - customers
  - inventory
  - invoices
  - payment_types
  - payments
  - preferences
  - product_attribute
  - product_value
  - products
  - tax_rates
  - user

- Updated the main settings navigation menu icon from `ti-settings` to `ti-adjustments-horizontal` in the menu template for better visual distinction

## Implementation Details
- The icon is only visible on medium screens and up (`d-none d-sm-inline`) to maintain the compact mobile layout
- The icon uses the `me-1` (margin-end) utility class to add proper spacing between the icon and text
- This change maintains backward compatibility and doesn't affect the dropdown menu functionality
- The icon styling is consistent with other action icons used throughout the application (e.g., `ti-eye`, `ti-edit`)

https://claude.ai/code/session_01BQPrZ44BaazjNvRkeUc5S7