### PR TITLE
Add "New Invoice" button to dashboard index page

### DIFF
--- a/templates/default/menu.blade.php
+++ b/templates/default/menu.blade.php
@@ -284,7 +284,11 @@
                 </div>
                 <div class="col-auto ms-auto d-print-none">
                     <div class="btn-list">
-                    @if(($module ?? '') == 'invoices' && ($view ?? '') == 'manage')
+                    @if(($module ?? '') == 'index' && ($view ?? '') == 'index')
+                        <a href="index.php?module=invoices&view=itemised" class="btn btn-primary">
+                            <i class="ti ti-plus me-1"></i>{{ $LANG['new_invoice'] ?? 'New Invoice' }}
+                        </a>
+                    @elseif(($module ?? '') == 'invoices' && ($view ?? '') == 'manage')
                         <a href="index.php?module=invoices&view=itemised" class="btn btn-primary">
                             <i class="ti ti-plus me-1"></i>{{ $LANG['new_invoice'] ?? 'New Invoice' }}
                         </a>


### PR DESCRIPTION
## Summary
Added the "New Invoice" button to the dashboard index page, making it accessible from the main dashboard view in addition to the existing invoices manage page.

## Key Changes
- Added a new conditional check to display the "New Invoice" button when on the index module and index view
- Converted the existing single `@if` statement to an `@if/@elseif` structure to support multiple page contexts
- The button maintains consistent styling and functionality across both the dashboard and invoices manage page

## Implementation Details
- The button links to `index.php?module=invoices&view=itemised` for creating new invoices
- Uses the same button styling and icon as the existing invoices manage page implementation
- Leverages the `$LANG` array for internationalization with a fallback to 'New Invoice'

https://claude.ai/code/session_01DcGb3hvDm5rQ3igqJ4nt6i