### PR TITLE
Fix default sort field in custom fields module

### DIFF
--- a/modules/custom_fields/manage.js.php
+++ b/modules/custom_fields/manage.js.php
@@ -30,7 +30,7 @@ var edit_tooltip = "{/literal}{$LANG.edit_view_tooltip} {$invoices.preference.pr
 				],
 				
 
-			sortname: 'cf_id',
+			sortname: 'cf_custom_field',
 			sortorder: 'asc',
 			usepager: false,
 			/*title: 'Manage Custom Fields',*/

--- a/modules/custom_fields/xml.php
+++ b/modules/custom_fields/xml.php
@@ -4,7 +4,7 @@ header("Content-type: text/xml");
 
 $start = (isset($_REQUEST['start'])) ? $_REQUEST['start'] : "0" ;
 $dir = (isset($_REQUEST['sortorder'])) ? $_REQUEST['sortorder'] : "ASC" ;
-$sort = (isset($_REQUEST['sortname'])) ? $_REQUEST['sortname'] : "cf_custom_label" ;
+$sort = (isset($_REQUEST['sortname'])) ? $_REQUEST['sortname'] : "cf_custom_field" ;
 $limit = (isset($_REQUEST['rp'])) ? $_REQUEST['rp'] : "25" ;
 $page = (isset($_REQUEST['page'])) ? $_REQUEST['page'] : "1" ;
 
@@ -27,12 +27,12 @@ if (!preg_match('/^(asc|desc)$/iD', $dir)) {
 $where = " WHERE domain_id = :domain_id";
 
 /*Check that the sort field is OK*/
-$validFields = array('cf_id', 'cf_custom_label','enabled');
+$validFields = array('cf_id', 'cf_custom_field', 'cf_custom_label','enabled');
 
 if (in_array($sort, $validFields)) {
 	$sort = $sort;
 } else {
-	$sort = "cf_custom_label";
+	$sort = "cf_custom_field";
 }
 
 /*


### PR DESCRIPTION
## Summary
Updated the default sorting field in the custom fields module from `cf_custom_label` to `cf_custom_field` for consistency across the XML and JavaScript configuration files.

## Key Changes
- Changed default sort field from `cf_custom_label` to `cf_custom_field` in `xml.php`
- Added `cf_custom_field` to the list of valid sortable fields in the validation array
- Updated the fallback sort field when an invalid sort is provided
- Updated the default `sortname` in `manage.js.php` to match the new default sort field

## Implementation Details
These changes ensure that:
- The custom fields grid defaults to sorting by the custom field name rather than the label
- The field is properly validated as an allowed sort option
- The JavaScript configuration and PHP backend are aligned on the default sort behavior

https://claude.ai/code/session_01HjEt5Vm6jmzaMGKCAfkqUK