### PR TITLE
Improve database backup UI with inline preview and copy-to-clipboard

### DIFF
--- a/modules/options/backup_database.php
+++ b/modules/options/backup_database.php
@@ -30,33 +30,31 @@ if (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST' && $op === 'backup_db') {
 	exit();
 }
 
-if (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST' && $op === 'view_backup') {
-	requireCSRFProtection($backup_action);
+// Always generate SQL for page display
+try {
+	$oBack  = new backup_db();
+	$handle = fopen('php://memory', 'r+');
+	$oBack->start_backup($handle);
+	rewind($handle);
+	$rawSQL = stream_get_contents($handle);
+	fclose($handle);
 
-	try {
-		$oBack  = new backup_db();
-		$handle = fopen('php://memory', 'r+');
-		$oBack->start_backup($handle);
-		rewind($handle);
-		$sql = stream_get_contents($handle);
-		fclose($handle);
-
-		$formatter  = new \Doctrine\SqlFormatter\SqlFormatter();
-		$statements = preg_split('/;\n/', $sql, -1, PREG_SPLIT_NO_EMPTY);
-		$parts      = [];
-		foreach ($statements as $stmt) {
-			$stmt = trim($stmt);
-			if ($stmt !== '') {
-				$parts[] = $formatter->format($stmt . ';');
-			}
+	$formatter  = new \Doctrine\SqlFormatter\SqlFormatter();
+	$statements = preg_split('/;\n/', $rawSQL, -1, PREG_SPLIT_NO_EMPTY);
+	$parts      = [];
+	foreach ($statements as $stmt) {
+		$stmt = trim($stmt);
+		if ($stmt !== '') {
+			$parts[] = $formatter->format($stmt . ';');
 		}
-		$formattedSQL = implode("\n", $parts);
-
-		$smarty->assign('formattedSQL', $formattedSQL);
-	} catch (\Throwable $e) {
-		$errors[] = 'SQL format error: ' . $e->getMessage();
-		error_log('backup view_backup error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
 	}
+	$formattedSQL = implode("\n", $parts);
+
+	$smarty->assign('formattedSQL', $formattedSQL);
+	$smarty->assign('rawSQL', $rawSQL);
+} catch (\Throwable $e) {
+	$errors[] = 'SQL format error: ' . $e->getMessage();
+	error_log('backup view_backup error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
 }
 
 $smarty->assign('backupActionToken', siNonce($backup_action));

--- a/templates/default/options/backup_database.blade.php
+++ b/templates/default/options/backup_database.blade.php
@@ -18,10 +18,10 @@
 	<input type="hidden" name="csrfprotectionbysr" value="{{ $backupActionToken ?? '' }}" />
 </form>
 
-<form method="post" action="index.php?module=options&amp;view=backup_database" id="form_view_backup">
-	<input type="hidden" name="op" value="view_backup" />
-	<input type="hidden" name="csrfprotectionbysr" value="{{ $backupActionToken ?? '' }}" />
-</form>
+{{-- Hidden textarea holding raw SQL for clipboard copy --}}
+@if(!empty($rawSQL))
+<textarea id="sql-raw-content" class="visually-hidden" aria-hidden="true" readonly>{{ $rawSQL }}</textarea>
+@endif
 
 <div class="card">
 	<div class="card-body">
@@ -34,35 +34,75 @@
 			</div>
 		@endif
 
-		<p class="text-secondary">{{ $LANG['backup_howto'] ?? '' }}</p>
-
-		<div>
-			<a class="cluetip btn btn-outline-secondary btn-sm" href="#" rel="index.php?module=documentation&amp;view=view&amp;page=help_backup_database" title="{{ $LANG['database_backup'] ?? 'Database backup' }}"><i class="ti ti-info-circle me-1"></i>{{ $LANG['more_info'] ?? '' }}</a>
-		</div>
+		<p class="text-secondary mb-0">{{ $LANG['backup_howto'] ?? '' }}</p>
 
 	</div>
+
+	@if(!empty($formattedSQL))
+	<div class="accordion accordion-flush border-top" id="sql-backup-accordion">
+		<div class="accordion-item">
+			<h2 class="accordion-header" id="sql-backup-heading">
+				<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#sql-backup-collapse" aria-expanded="true" aria-controls="sql-backup-collapse">
+					<i class="ti ti-database me-2"></i>{{ $LANG['database_backup'] ?? 'Database Backup' }}
+				</button>
+			</h2>
+			<div id="sql-backup-collapse" class="accordion-collapse collapse show" aria-labelledby="sql-backup-heading">
+				<div class="accordion-body p-0">
+					<div class="d-flex align-items-center gap-2 px-3 py-2 border-bottom bg-body-tertiary">
+						<button type="button" class="btn btn-sm btn-outline-secondary" id="btn-copy-sql" onclick="copySQLToClipboard(this)" title="Copy SQL to clipboard">
+							<i class="ti ti-copy me-1"></i>Copy
+						</button>
+						<button type="submit" form="form_backup_db" class="btn btn-sm btn-outline-secondary" title="{{ $LANG['backup_database_now'] ?? 'Download SQL backup' }}">
+							<i class="ti ti-download me-1"></i>{{ $LANG['backup_database_now'] ?? 'Download' }}
+						</button>
+					</div>
+					<div class="overflow-auto p-3" style="max-height: 70vh;">
+						{!! $formattedSQL !!}
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	@endif
+
 	<div class="card-footer">
-		<div class="d-flex">
+		<div class="d-flex align-items-center">
 			<a href="./index.php?module=options&amp;view=index" class="btn btn-link">{{ $LANG['cancel'] ?? '' }}</a>
-			<div class="ms-auto d-flex gap-2">
-				@if(!empty($formattedSQL))
-				<button type="submit" form="form_backup_db" class="btn btn-outline-secondary">
-					<i class="ti ti-download me-1"></i>{{ $LANG['backup_database_now'] ?? 'Download' }}
-				</button>
-				@endif
-				<button type="submit" form="form_view_backup" class="btn btn-outline-secondary">
-					<i class="ti ti-eye me-1"></i>{{ $LANG['view_in_browser'] ?? 'View in Browser' }}
-				</button>
+			@if(empty($formattedSQL))
+			<div class="ms-auto">
 				<button type="submit" form="form_backup_db" class="btn btn-primary">
 					<i class="ti ti-download me-1"></i>{{ $LANG['backup_database_now'] ?? 'Download' }}
 				</button>
 			</div>
+			@endif
 		</div>
 	</div>
-
-	@if(!empty($formattedSQL))
-	<div class="card-body border-top overflow-auto" style="max-height: 70vh;">
-		{!! $formattedSQL !!}
-	</div>
-	@endif
 </div>
+
+<script>
+function copySQLToClipboard(btn) {
+	var textarea = document.getElementById('sql-raw-content');
+	if (!textarea) return;
+
+	var originalHTML = btn.innerHTML;
+
+	navigator.clipboard.writeText(textarea.value).then(function() {
+		btn.innerHTML = '<i class="ti ti-check me-1"></i>Copied!';
+		btn.classList.remove('btn-outline-secondary');
+		btn.classList.add('btn-success');
+		setTimeout(function() {
+			btn.innerHTML = originalHTML;
+			btn.classList.remove('btn-success');
+			btn.classList.add('btn-outline-secondary');
+		}, 2000);
+	}).catch(function() {
+		// Fallback for browsers without clipboard API
+		textarea.classList.remove('visually-hidden');
+		textarea.select();
+		try {
+			document.execCommand('copy');
+		} catch(e) {}
+		textarea.classList.add('visually-hidden');
+	});
+}
+</script>


### PR DESCRIPTION
## Summary
Refactored the database backup interface to display formatted SQL inline with improved user experience features, including a copy-to-clipboard button and better visual organization.

## Key Changes
- **Removed separate view action**: Eliminated the `view_backup` POST operation and its dedicated form, consolidating functionality into the main backup page
- **Always generate SQL preview**: Changed SQL generation from conditional (only on view request) to always occur when the page loads, making the formatted backup immediately visible
- **Added copy-to-clipboard functionality**: Implemented a new `copySQLToClipboard()` JavaScript function that copies raw SQL to the clipboard with visual feedback (success state for 2 seconds)
- **Reorganized UI layout**: 
  - Moved SQL display into a Bootstrap accordion component for better space management
  - Added action buttons (Copy and Download) in a toolbar above the SQL preview
  - Improved responsive design with `max-height: 70vh` scrollable container
  - Simplified footer button logic to only show download when SQL isn't already displayed
- **Enhanced accessibility**: 
  - Added hidden textarea (`sql-raw-content`) to store raw SQL for clipboard operations
  - Used `visually-hidden` and `aria-hidden` attributes for semantic HTML
  - Maintained CSRF protection token handling

## Implementation Details
- The raw SQL is now stored in a hidden textarea for reliable clipboard copying across browsers
- Fallback mechanism provided for browsers without Clipboard API support
- SQL formatting and display happens server-side on every page load, eliminating the need for separate view requests
- Button state management provides visual confirmation of successful copy action

https://claude.ai/code/session_01YVtBoQd7ynCgRNG7o5dGYB