### PR TITLE
Add PostgreSQL and SQLite support with database-agnostic queries

### DIFF
--- a/.env
+++ b/.env
@@ -1,19 +1,29 @@
 # Simple Invoices – Docker environment
 # Copy to .env and adjust as needed. Do not commit real credentials.
+#
+# ── Database adapter ──────────────────────────────────────────────────────────
+# Three adapters are supported. Uncomment the block you want and comment out the
+# others.  Then choose the matching docker-compose command:
+#
+#   MySQL/MariaDB (default):
+#     docker compose up
+#
+#   SQLite (no db service required):
+#     docker compose -f docker-compose.yml -f docker-compose.sqlite.yml up
+#
+#   PostgreSQL:
+#     docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up
+# ─────────────────────────────────────────────────────────────────────────────
 
-# --- App (simpleinvoices) ---
+# ── MySQL / MariaDB ───────────────────────────────────────────────────────────
+SI_DATABASE_ADAPTER=pdo_mysql
 SI_DB_HOST=db
 SI_DB_PORT=3306
 SI_DB_USER=root
 SI_DB_PASSWORD=rootpassword
 SI_DB_NAME=simple_invoices
-# Header branding (optional; can also set in config/custom.config.php as app.name and app.logo)
-SI_APP_NAME=Simple Invoices
-SI_APP_LOGO=
-APP_ENV=local
-APP_DEBUG=true
 
-# --- Database (MariaDB) ---
+# --- Database (MariaDB service) ---
 MYSQL_ROOT_PASSWORD=rootpassword
 MYSQL_DATABASE=simple_invoices
 MYSQL_USER=simpleuser
@@ -23,14 +33,43 @@ MYSQL_PASSWORD=simplepass
 ADMINER_DEFAULT_SERVER=db
 ADMINER_DEFAULT_USERNAME=root
 ADMINER_DEFAULT_PASSWORD=rootpassword
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── SQLite ────────────────────────────────────────────────────────────────────
+# Use with: docker compose -f docker-compose.yml -f docker-compose.sqlite.yml up
+# Uncomment and comment out the MySQL block above to switch.
+#SI_DATABASE_ADAPTER=pdo_sqlite
+#SI_DB_HOST=
+#SI_DB_PORT=
+#SI_DB_USER=
+#SI_DB_PASSWORD=
+#SI_DB_NAME=simple_invoices
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+# Use with: docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up
+# Uncomment and comment out the MySQL block above to switch.
+#SI_DATABASE_ADAPTER=pdo_pgsql
+#SI_DB_HOST=db
+#SI_DB_PORT=5432
+#SI_DB_USER=siuser
+#SI_DB_PASSWORD=sipassword
+#SI_DB_NAME=simple_invoices
+#POSTGRES_PASSWORD=sipassword
+#POSTGRES_DB=simple_invoices
+#POSTGRES_USER=siuser
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- App ---
+SI_APP_NAME=Simple Invoices
+SI_APP_LOGO=
+APP_ENV=local
+APP_DEBUG=true
 
 # --- Ports (host:container) ---
 SI_APP_PORT=8888
 DB_PORT=3307
 ADMINER_PORT=8081
-
-# --- App extras (config/config.php overrides for Docker) ---
-SI_DATABASE_ADAPTER=pdo_mysql
 SI_DATABASE_UTF8=true
 SI_AUTHENTICATION_ENABLED=false
 SI_AUTHENTICATION_HTTP=

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,25 @@ RUN apk add --no-cache \
     nginx
 
 # PHP extensions (dom/xml for htmlpurifier etc.)
-RUN apk add --no-cache icu-dev \
+# pdo_sqlite: built into PHP but needs sqlite-dev at build time
+# pdo_pgsql:  needs libpq-dev at build and libpq at runtime
+RUN apk add --no-cache icu-dev sqlite-dev libpq-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
     mysqli \
     pdo \
     pdo_mysql \
+    pdo_sqlite \
+    pdo_pgsql \
+    pgsql \
     mbstring \
     zip \
     gd \
     dom \
     xml \
     intl \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && apk add --no-cache libpq sqlite-libs
 
 # Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/databases/mysql/structure.sql
+++ b/databases/mysql/structure.sql
@@ -1,8 +1,17 @@
 SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 SET @saved_cs_client     = @@character_set_client;
 SET @saved_col_client    = @@collation_database;
-SET character_set_client = utf8;
-SET collation_database   = utf8_unicode_ci;
+SET character_set_client = utf8mb4;
+SET collation_database   = utf8mb4_unicode_ci;
+
+-- Note on AUTO_INCREMENT with composite primary keys:
+-- InnoDB requires the AUTO_INCREMENT column to be leftmost in at least one index.
+-- Where the composite PK is (domain_id, id), id is not leftmost, so a plain
+-- KEY (id) is added to each affected table.  This satisfies InnoDB without
+-- changing the PK column order or the application's query patterns.
+-- The per-domain-group auto-increment behaviour of MyISAM is not used by the
+-- application (all queries scope by both domain_id and id), so the switch to a
+-- globally-incrementing sequence under InnoDB is safe.
 
 CREATE TABLE IF NOT EXISTS `si_biller` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
@@ -31,8 +40,9 @@ CREATE TABLE IF NOT EXISTS `si_biller` (
   `custom_field3` varchar(255) DEFAULT NULL,
   `custom_field4` varchar(255) DEFAULT NULL,
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
-  PRIMARY KEY (`domain_id`,`id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_cron` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -44,8 +54,9 @@ CREATE TABLE IF NOT EXISTS `si_cron` (
   `recurrence_type` varchar(11) NOT NULL,
   `email_biller` TINYINT(1) DEFAULT 0 NOT NULL,
   `email_customer` TINYINT(1) DEFAULT 0 NOT NULL,
-  PRIMARY KEY (`domain_id`,`id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_cron_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -53,8 +64,9 @@ CREATE TABLE IF NOT EXISTS `si_cron_log` (
   `cron_id` varchar(25) DEFAULT NULL,
   `run_date` date NOT NULL,
   PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`),
   UNIQUE KEY `CronIdUnq` (`domain_id`, `cron_id`, `run_date`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_custom_fields` (
   `cf_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -63,7 +75,7 @@ CREATE TABLE IF NOT EXISTS `si_custom_fields` (
   `cf_display` TINYINT(1) DEFAULT 1 NOT NULL,
   `domain_id` int(11) NOT NULL,
   PRIMARY KEY (`cf_id`, `domain_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_customers` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
@@ -87,8 +99,9 @@ CREATE TABLE IF NOT EXISTS `si_customers` (
   `custom_field3` varchar(255) DEFAULT NULL,
   `custom_field4` varchar(255) DEFAULT NULL,
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
-  PRIMARY KEY (`domain_id`,`id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_extensions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -97,7 +110,7 @@ CREATE TABLE IF NOT EXISTS `si_extensions` (
   `description` varchar(255) NOT NULL,
   `enabled` TINYINT(1) DEFAULT 0 NOT NULL,
   PRIMARY KEY (`id`, `domain_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_index` (
   `id` int(11) NOT NULL,
@@ -105,7 +118,7 @@ CREATE TABLE IF NOT EXISTS `si_index` (
   `sub_node` varchar(255) DEFAULT NULL,
   `sub_node_2` varchar(255) DEFAULT NULL,
   `domain_id` int(11) NOT NULL
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_inventory` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -115,8 +128,9 @@ CREATE TABLE IF NOT EXISTS `si_inventory` (
   `cost` decimal(25,6) DEFAULT NULL,
   `date` date NOT NULL,
   `note` text,
-  PRIMARY KEY (`domain_id`,`id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_invoice_item_tax` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -127,7 +141,7 @@ CREATE TABLE IF NOT EXISTS `si_invoice_item_tax` (
   `tax_amount` decimal(25,6) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UnqInvTax` (`invoice_item_id`, `tax_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_invoice_items` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
@@ -144,13 +158,13 @@ CREATE TABLE IF NOT EXISTS `si_invoice_items` (
   PRIMARY KEY (`id`),
   KEY `invoice_id` (`invoice_id`),
   KEY `DomainInv` (`invoice_id`, `domain_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_invoice_type` (
   `inv_ty_id` int(11) NOT NULL AUTO_INCREMENT,
   `inv_ty_description` varchar(25) NOT NULL DEFAULT '',
   PRIMARY KEY (`inv_ty_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_invoices` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
@@ -167,12 +181,13 @@ CREATE TABLE IF NOT EXISTS `si_invoices` (
   `custom_field4` varchar(50) DEFAULT NULL,
   `note` text,
   PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`),
   KEY `domain_id` (`domain_id`),
   KEY `biller_id` (`biller_id`),
   KEY `customer_id` (`customer_id`),
-  KEY `UniqDIB` (`index_id`, `preference_id`, `biller_id`, `domain_id`), 
+  UNIQUE KEY `UniqDIB` (`index_id`, `preference_id`, `biller_id`, `domain_id`),
   KEY `IdxDI` (`index_id`, `preference_id`, `domain_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_log` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -182,7 +197,7 @@ CREATE TABLE IF NOT EXISTS `si_log` (
   `sqlquerie` text NOT NULL,
   `last_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`, `domain_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_payment` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
@@ -194,18 +209,20 @@ CREATE TABLE IF NOT EXISTS `si_payment` (
   `domain_id` int(11) NOT NULL,
   `online_payment_id` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`),
   KEY `domain_id` (`domain_id`),
   KEY `ac_inv_id` (`ac_inv_id`),
   KEY `ac_amount` (`ac_amount`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_payment_types` (
   `pt_id` int(10) NOT NULL AUTO_INCREMENT,
   `domain_id` int(11) NOT NULL DEFAULT '1',
   `pt_description` varchar(250) NOT NULL,
   `pt_enabled` TINYINT(1) DEFAULT 1 NOT NULL,
-  PRIMARY KEY (`domain_id`,`pt_id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`pt_id`),
+  KEY `pt_id` (`pt_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_preferences` (
   `pref_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -229,8 +246,9 @@ CREATE TABLE IF NOT EXISTS `si_preferences` (
   `currency_code` varchar(25) DEFAULT NULL,
   `include_online_payment` varchar(255) DEFAULT NULL,
   `currency_position` varchar(25) DEFAULT NULL,
-  PRIMARY KEY (`domain_id`,`pref_id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`pref_id`),
+  KEY `pref_id` (`pref_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_products` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -251,14 +269,15 @@ CREATE TABLE IF NOT EXISTS `si_products` (
   `attribute` varchar(255) DEFAULT NULL,
   `notes_as_description` CHAR(1) DEFAULT NULL,
   `show_description` CHAR(1) DEFAULT NULL,
-  PRIMARY KEY (`domain_id`,`id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_products_attribute_type` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_products_attributes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -267,7 +286,7 @@ CREATE TABLE IF NOT EXISTS `si_products_attributes` (
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
   `visible` TINYINT(1) DEFAULT 1 NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_products_values` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -275,7 +294,7 @@ CREATE TABLE IF NOT EXISTS `si_products_values` (
   `value` varchar(255) NOT NULL,
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_sql_patchmanager` (
   `sql_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -284,7 +303,7 @@ CREATE TABLE IF NOT EXISTS `si_sql_patchmanager` (
   `sql_release` varchar(25) DEFAULT NULL ,
   `sql_statement` text DEFAULT NULL,
   PRIMARY KEY (`sql_id`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_system_defaults` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -293,8 +312,9 @@ CREATE TABLE IF NOT EXISTS `si_system_defaults` (
   `domain_id` int(5) NOT NULL DEFAULT '0',
   `extension_id` int(5) NOT NULL DEFAULT '0',
   PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`),
   UNIQUE KEY `UnqNameInDomain` (`domain_id`, `name`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_tax` (
   `tax_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -303,8 +323,9 @@ CREATE TABLE IF NOT EXISTS `si_tax` (
   `type` CHAR(1) DEFAULT '%' NOT NULL,
   `tax_enabled` TINYINT(1) DEFAULT 1 NOT NULL,
   `domain_id` int(11) NOT NULL,
-  PRIMARY KEY (`domain_id`,`tax_id`)
-) ENGINE=MyISAM;
+  PRIMARY KEY (`domain_id`,`tax_id`),
+  KEY `tax_id` (`tax_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_user` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -316,22 +337,23 @@ CREATE TABLE IF NOT EXISTS `si_user` (
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`domain_id`,`id`),
+  KEY `id` (`id`),
   UNIQUE KEY `UnqEMail` (`email`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_user_domain` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(191) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_user_role` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(191) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 SET character_set_client = @saved_cs_client;
 SET collation_database   = @saved_col_client;

--- a/databases/pgsql/structure.sql
+++ b/databases/pgsql/structure.sql
@@ -1,0 +1,331 @@
+-- Simple Invoices - PostgreSQL Schema
+-- Converted from MySQL structure; requires PostgreSQL 9.5+
+
+CREATE TABLE IF NOT EXISTS si_biller (
+  id           SERIAL,
+  domain_id    INTEGER NOT NULL DEFAULT 1,
+  name         VARCHAR(255) DEFAULT NULL,
+  street_address  VARCHAR(255) DEFAULT NULL,
+  street_address2 VARCHAR(255) DEFAULT NULL,
+  city         VARCHAR(255) DEFAULT NULL,
+  state        VARCHAR(255) DEFAULT NULL,
+  zip_code     VARCHAR(20) DEFAULT NULL,
+  country      VARCHAR(255) DEFAULT NULL,
+  phone        VARCHAR(255) DEFAULT NULL,
+  mobile_phone VARCHAR(255) DEFAULT NULL,
+  fax          VARCHAR(255) DEFAULT NULL,
+  email        VARCHAR(255) DEFAULT NULL,
+  logo         VARCHAR(255) DEFAULT NULL,
+  footer       TEXT,
+  paypal_business_name   VARCHAR(255) DEFAULT NULL,
+  paypal_notify_url      VARCHAR(255) DEFAULT NULL,
+  paypal_return_url      VARCHAR(255) DEFAULT NULL,
+  eway_customer_id       VARCHAR(255) DEFAULT NULL,
+  paymentsgateway_api_id VARCHAR(255) DEFAULT NULL,
+  notes        TEXT,
+  custom_field1 VARCHAR(255) DEFAULT NULL,
+  custom_field2 VARCHAR(255) DEFAULT NULL,
+  custom_field3 VARCHAR(255) DEFAULT NULL,
+  custom_field4 VARCHAR(255) DEFAULT NULL,
+  enabled      SMALLINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (domain_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS si_cron (
+  id               SERIAL,
+  domain_id        INTEGER NOT NULL,
+  invoice_id       INTEGER NOT NULL,
+  start_date       DATE NOT NULL,
+  end_date         VARCHAR(10) DEFAULT NULL,
+  recurrence       INTEGER NOT NULL,
+  recurrence_type  VARCHAR(11) NOT NULL,
+  email_biller     SMALLINT NOT NULL DEFAULT 0,
+  email_customer   SMALLINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (domain_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS si_cron_log (
+  id        SERIAL,
+  domain_id INTEGER NOT NULL,
+  cron_id   VARCHAR(25) DEFAULT NULL,
+  run_date  DATE NOT NULL,
+  PRIMARY KEY (domain_id, id),
+  UNIQUE (domain_id, cron_id, run_date)
+);
+
+CREATE TABLE IF NOT EXISTS si_custom_fields (
+  cf_id           SERIAL,
+  cf_custom_field VARCHAR(255) DEFAULT NULL,
+  cf_custom_label VARCHAR(255) DEFAULT NULL,
+  cf_display      SMALLINT NOT NULL DEFAULT 1,
+  domain_id       INTEGER NOT NULL,
+  PRIMARY KEY (cf_id, domain_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_customers (
+  id             SERIAL,
+  domain_id      INTEGER NOT NULL DEFAULT 1,
+  attention      VARCHAR(255) DEFAULT NULL,
+  name           VARCHAR(255) DEFAULT NULL,
+  department     VARCHAR(255) DEFAULT NULL,
+  street_address  VARCHAR(255) DEFAULT NULL,
+  street_address2 VARCHAR(255) DEFAULT NULL,
+  city           VARCHAR(255) DEFAULT NULL,
+  state          VARCHAR(255) DEFAULT NULL,
+  zip_code       VARCHAR(20) DEFAULT NULL,
+  country        VARCHAR(255) DEFAULT NULL,
+  phone          VARCHAR(255) DEFAULT NULL,
+  mobile_phone   VARCHAR(255) DEFAULT NULL,
+  fax            VARCHAR(255) DEFAULT NULL,
+  email          VARCHAR(255) DEFAULT NULL,
+  notes          TEXT,
+  custom_field1  VARCHAR(255) DEFAULT NULL,
+  custom_field2  VARCHAR(255) DEFAULT NULL,
+  custom_field3  VARCHAR(255) DEFAULT NULL,
+  custom_field4  VARCHAR(255) DEFAULT NULL,
+  enabled        SMALLINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (domain_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS si_extensions (
+  id          SERIAL,
+  domain_id   INTEGER NOT NULL,
+  name        VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  enabled     SMALLINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (id, domain_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_index (
+  id         INTEGER NOT NULL,
+  node       VARCHAR(255) NOT NULL,
+  sub_node   VARCHAR(255) DEFAULT NULL,
+  sub_node_2 VARCHAR(255) DEFAULT NULL,
+  domain_id  INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS si_inventory (
+  id         SERIAL,
+  domain_id  INTEGER NOT NULL,
+  product_id INTEGER NOT NULL,
+  quantity   NUMERIC(25,6) NOT NULL,
+  cost       NUMERIC(25,6) DEFAULT NULL,
+  date       DATE NOT NULL,
+  note       TEXT,
+  PRIMARY KEY (domain_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS si_invoice_item_tax (
+  id              SERIAL,
+  invoice_item_id INTEGER NOT NULL,
+  tax_id          INTEGER NOT NULL,
+  tax_type        CHAR(1) NOT NULL DEFAULT '%',
+  tax_rate        NUMERIC(25,6) NOT NULL,
+  tax_amount      NUMERIC(25,6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (invoice_item_id, tax_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_invoice_items (
+  id          SERIAL,
+  invoice_id  INTEGER NOT NULL DEFAULT 0,
+  domain_id   INTEGER NOT NULL DEFAULT 1,
+  quantity    NUMERIC(25,6) NOT NULL DEFAULT 0,
+  product_id  INTEGER DEFAULT 0,
+  unit_price  NUMERIC(25,6) DEFAULT 0,
+  tax_amount  NUMERIC(25,6) DEFAULT 0,
+  gross_total NUMERIC(25,6) DEFAULT 0,
+  description TEXT,
+  total       NUMERIC(25,6) DEFAULT 0,
+  attribute   VARCHAR(255) DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX IF NOT EXISTS si_invoice_items_invoice_id ON si_invoice_items (invoice_id);
+CREATE INDEX IF NOT EXISTS si_invoice_items_domain_inv ON si_invoice_items (invoice_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_invoice_type (
+  inv_ty_id          SERIAL,
+  inv_ty_description VARCHAR(25) NOT NULL DEFAULT '',
+  PRIMARY KEY (inv_ty_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_invoices (
+  id            SERIAL,
+  index_id      INTEGER NOT NULL,
+  domain_id     INTEGER NOT NULL DEFAULT 1,
+  biller_id     INTEGER NOT NULL DEFAULT 0,
+  customer_id   INTEGER NOT NULL DEFAULT 0,
+  type_id       INTEGER NOT NULL DEFAULT 0,
+  preference_id INTEGER NOT NULL DEFAULT 0,
+  date          TIMESTAMP NOT NULL DEFAULT '0001-01-01 00:00:00',
+  custom_field1 VARCHAR(50) DEFAULT NULL,
+  custom_field2 VARCHAR(50) DEFAULT NULL,
+  custom_field3 VARCHAR(50) DEFAULT NULL,
+  custom_field4 VARCHAR(50) DEFAULT NULL,
+  note          TEXT,
+  PRIMARY KEY (domain_id, id)
+);
+CREATE INDEX IF NOT EXISTS si_invoices_domain_id  ON si_invoices (domain_id);
+CREATE INDEX IF NOT EXISTS si_invoices_biller_id  ON si_invoices (biller_id);
+CREATE INDEX IF NOT EXISTS si_invoices_customer_id ON si_invoices (customer_id);
+CREATE UNIQUE INDEX IF NOT EXISTS si_invoices_uniq_dib ON si_invoices (index_id, preference_id, biller_id, domain_id);
+CREATE INDEX IF NOT EXISTS si_invoices_idx_di ON si_invoices (index_id, preference_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_log (
+  id         BIGSERIAL,
+  domain_id  INTEGER NOT NULL DEFAULT 1,
+  timestamp  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  userid     INTEGER NOT NULL DEFAULT 1,
+  sqlquerie  TEXT NOT NULL,
+  last_id    INTEGER DEFAULT NULL,
+  PRIMARY KEY (id, domain_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_payment (
+  id                SERIAL,
+  ac_inv_id         INTEGER NOT NULL,
+  ac_amount         NUMERIC(25,6) NOT NULL,
+  ac_notes          TEXT NOT NULL,
+  ac_date           TIMESTAMP NOT NULL,
+  ac_payment_type   INTEGER NOT NULL DEFAULT 1,
+  domain_id         INTEGER NOT NULL,
+  online_payment_id VARCHAR(255) DEFAULT NULL,
+  PRIMARY KEY (domain_id, id)
+);
+CREATE INDEX IF NOT EXISTS si_payment_domain_id ON si_payment (domain_id);
+CREATE INDEX IF NOT EXISTS si_payment_ac_inv_id ON si_payment (ac_inv_id);
+CREATE INDEX IF NOT EXISTS si_payment_ac_amount ON si_payment (ac_amount);
+
+CREATE TABLE IF NOT EXISTS si_payment_types (
+  pt_id          SERIAL,
+  domain_id      INTEGER NOT NULL DEFAULT 1,
+  pt_description VARCHAR(250) NOT NULL,
+  pt_enabled     SMALLINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (domain_id, pt_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_preferences (
+  pref_id                    SERIAL,
+  domain_id                  INTEGER NOT NULL DEFAULT 1,
+  pref_description           VARCHAR(50) DEFAULT NULL,
+  pref_currency_sign         VARCHAR(50) DEFAULT NULL,
+  pref_inv_heading           VARCHAR(50) DEFAULT NULL,
+  pref_inv_wording           VARCHAR(50) DEFAULT NULL,
+  pref_inv_detail_heading    VARCHAR(50) DEFAULT NULL,
+  pref_inv_detail_line       TEXT,
+  pref_inv_payment_method    VARCHAR(50) DEFAULT NULL,
+  pref_inv_payment_line1_name  VARCHAR(50) DEFAULT NULL,
+  pref_inv_payment_line1_value VARCHAR(50) DEFAULT NULL,
+  pref_inv_payment_line2_name  VARCHAR(50) DEFAULT NULL,
+  pref_inv_payment_line2_value VARCHAR(50) DEFAULT NULL,
+  pref_enabled               SMALLINT NOT NULL DEFAULT 1,
+  status                     SMALLINT NOT NULL,
+  locale                     VARCHAR(255) DEFAULT NULL,
+  language                   VARCHAR(255) DEFAULT NULL,
+  index_group                INTEGER NOT NULL,
+  currency_code              VARCHAR(25) DEFAULT NULL,
+  include_online_payment     VARCHAR(255) DEFAULT NULL,
+  currency_position          VARCHAR(25) DEFAULT NULL,
+  PRIMARY KEY (domain_id, pref_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_products (
+  id                   SERIAL,
+  domain_id            INTEGER NOT NULL DEFAULT 1,
+  description          TEXT NOT NULL,
+  unit_price           NUMERIC(25,6) DEFAULT 0,
+  default_tax_id       INTEGER DEFAULT NULL,
+  default_tax_id_2     INTEGER DEFAULT NULL,
+  cost                 NUMERIC(25,6) DEFAULT 0,
+  reorder_level        INTEGER DEFAULT NULL,
+  custom_field1        VARCHAR(255) DEFAULT NULL,
+  custom_field2        VARCHAR(255) DEFAULT NULL,
+  custom_field3        VARCHAR(255) DEFAULT NULL,
+  custom_field4        VARCHAR(255) DEFAULT NULL,
+  notes                TEXT DEFAULT NULL,
+  enabled              SMALLINT NOT NULL DEFAULT 1,
+  visible              SMALLINT NOT NULL DEFAULT 1,
+  attribute            VARCHAR(255) DEFAULT NULL,
+  notes_as_description CHAR(1) DEFAULT NULL,
+  show_description     CHAR(1) DEFAULT NULL,
+  PRIMARY KEY (domain_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS si_products_attribute_type (
+  id   SERIAL,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS si_products_attributes (
+  id      SERIAL,
+  name    VARCHAR(255) NOT NULL,
+  type_id VARCHAR(255) NOT NULL,
+  enabled SMALLINT NOT NULL DEFAULT 1,
+  visible SMALLINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS si_products_values (
+  id           SERIAL,
+  attribute_id INTEGER NOT NULL,
+  value        VARCHAR(255) NOT NULL,
+  enabled      SMALLINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS si_sql_patchmanager (
+  sql_id        SERIAL,
+  sql_patch_ref INTEGER NOT NULL,
+  sql_patch     VARCHAR(255) DEFAULT NULL,
+  sql_release   VARCHAR(25) DEFAULT NULL,
+  sql_statement TEXT DEFAULT NULL,
+  PRIMARY KEY (sql_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_system_defaults (
+  id           SERIAL,
+  name         VARCHAR(30) NOT NULL,
+  value        VARCHAR(30) DEFAULT NULL,
+  domain_id    INTEGER NOT NULL DEFAULT 0,
+  extension_id INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (domain_id, id),
+  UNIQUE (domain_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS si_tax (
+  tax_id          SERIAL,
+  tax_description VARCHAR(50) DEFAULT NULL,
+  tax_percentage  NUMERIC(25,6) DEFAULT 0,
+  type            CHAR(1) NOT NULL DEFAULT '%',
+  tax_enabled     SMALLINT NOT NULL DEFAULT 1,
+  domain_id       INTEGER NOT NULL,
+  PRIMARY KEY (domain_id, tax_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_user (
+  id        SERIAL,
+  email     VARCHAR(255) DEFAULT NULL,
+  name      VARCHAR(255) DEFAULT NULL,
+  role_id   INTEGER DEFAULT NULL,
+  domain_id INTEGER NOT NULL DEFAULT 0,
+  password  VARCHAR(64) DEFAULT NULL,
+  enabled   SMALLINT NOT NULL DEFAULT 1,
+  user_id   INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (domain_id, id),
+  UNIQUE (email)
+);
+
+CREATE TABLE IF NOT EXISTS si_user_domain (
+  id   SERIAL,
+  name VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (name)
+);
+
+CREATE TABLE IF NOT EXISTS si_user_role (
+  id   SERIAL,
+  name VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (name)
+);

--- a/databases/sqlite/structure.sql
+++ b/databases/sqlite/structure.sql
@@ -1,0 +1,322 @@
+-- Simple Invoices - SQLite Schema
+-- Converted from MySQL structure; requires SQLite 3.24+
+
+CREATE TABLE IF NOT EXISTS si_biller (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id      INTEGER NOT NULL DEFAULT 1,
+  name           TEXT DEFAULT NULL,
+  street_address  TEXT DEFAULT NULL,
+  street_address2 TEXT DEFAULT NULL,
+  city           TEXT DEFAULT NULL,
+  state          TEXT DEFAULT NULL,
+  zip_code       TEXT DEFAULT NULL,
+  country        TEXT DEFAULT NULL,
+  phone          TEXT DEFAULT NULL,
+  mobile_phone   TEXT DEFAULT NULL,
+  fax            TEXT DEFAULT NULL,
+  email          TEXT DEFAULT NULL,
+  logo           TEXT DEFAULT NULL,
+  footer         TEXT,
+  paypal_business_name   TEXT DEFAULT NULL,
+  paypal_notify_url      TEXT DEFAULT NULL,
+  paypal_return_url      TEXT DEFAULT NULL,
+  eway_customer_id       TEXT DEFAULT NULL,
+  paymentsgateway_api_id TEXT DEFAULT NULL,
+  notes          TEXT,
+  custom_field1  TEXT DEFAULT NULL,
+  custom_field2  TEXT DEFAULT NULL,
+  custom_field3  TEXT DEFAULT NULL,
+  custom_field4  TEXT DEFAULT NULL,
+  enabled        INTEGER NOT NULL DEFAULT 1
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_biller_pk ON si_biller (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_cron (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id       INTEGER NOT NULL,
+  invoice_id      INTEGER NOT NULL,
+  start_date      TEXT NOT NULL,
+  end_date        TEXT DEFAULT NULL,
+  recurrence      INTEGER NOT NULL,
+  recurrence_type TEXT NOT NULL,
+  email_biller    INTEGER NOT NULL DEFAULT 0,
+  email_customer  INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_cron_pk ON si_cron (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_cron_log (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id INTEGER NOT NULL,
+  cron_id   TEXT DEFAULT NULL,
+  run_date  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_cron_log_pk  ON si_cron_log (domain_id, id);
+CREATE UNIQUE INDEX IF NOT EXISTS si_cron_log_unq ON si_cron_log (domain_id, cron_id, run_date);
+
+CREATE TABLE IF NOT EXISTS si_custom_fields (
+  cf_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  cf_custom_field TEXT DEFAULT NULL,
+  cf_custom_label TEXT DEFAULT NULL,
+  cf_display      INTEGER NOT NULL DEFAULT 1,
+  domain_id       INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_custom_fields_pk ON si_custom_fields (cf_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_customers (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id      INTEGER NOT NULL DEFAULT 1,
+  attention      TEXT DEFAULT NULL,
+  name           TEXT DEFAULT NULL,
+  department     TEXT DEFAULT NULL,
+  street_address  TEXT DEFAULT NULL,
+  street_address2 TEXT DEFAULT NULL,
+  city           TEXT DEFAULT NULL,
+  state          TEXT DEFAULT NULL,
+  zip_code       TEXT DEFAULT NULL,
+  country        TEXT DEFAULT NULL,
+  phone          TEXT DEFAULT NULL,
+  mobile_phone   TEXT DEFAULT NULL,
+  fax            TEXT DEFAULT NULL,
+  email          TEXT DEFAULT NULL,
+  notes          TEXT,
+  custom_field1  TEXT DEFAULT NULL,
+  custom_field2  TEXT DEFAULT NULL,
+  custom_field3  TEXT DEFAULT NULL,
+  custom_field4  TEXT DEFAULT NULL,
+  enabled        INTEGER NOT NULL DEFAULT 1
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_customers_pk ON si_customers (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_extensions (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id   INTEGER NOT NULL,
+  name        TEXT NOT NULL,
+  description TEXT NOT NULL,
+  enabled     INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_extensions_pk ON si_extensions (id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_index (
+  id         INTEGER NOT NULL,
+  node       TEXT NOT NULL,
+  sub_node   TEXT DEFAULT NULL,
+  sub_node_2 TEXT DEFAULT NULL,
+  domain_id  INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS si_inventory (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id  INTEGER NOT NULL,
+  product_id INTEGER NOT NULL,
+  quantity   REAL NOT NULL,
+  cost       REAL DEFAULT NULL,
+  date       TEXT NOT NULL,
+  note       TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_inventory_pk ON si_inventory (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_invoice_item_tax (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  invoice_item_id INTEGER NOT NULL,
+  tax_id          INTEGER NOT NULL,
+  tax_type        TEXT NOT NULL DEFAULT '%',
+  tax_rate        REAL NOT NULL,
+  tax_amount      REAL NOT NULL,
+  UNIQUE (invoice_item_id, tax_id)
+);
+
+CREATE TABLE IF NOT EXISTS si_invoice_items (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  invoice_id  INTEGER NOT NULL DEFAULT 0,
+  domain_id   INTEGER NOT NULL DEFAULT 1,
+  quantity    REAL NOT NULL DEFAULT 0,
+  product_id  INTEGER DEFAULT 0,
+  unit_price  REAL DEFAULT 0,
+  tax_amount  REAL DEFAULT 0,
+  gross_total REAL DEFAULT 0,
+  description TEXT,
+  total       REAL DEFAULT 0,
+  attribute   TEXT DEFAULT NULL
+);
+CREATE INDEX IF NOT EXISTS si_invoice_items_invoice_id ON si_invoice_items (invoice_id);
+CREATE INDEX IF NOT EXISTS si_invoice_items_domain_inv ON si_invoice_items (invoice_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_invoice_type (
+  inv_ty_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  inv_ty_description TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS si_invoices (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  index_id      INTEGER NOT NULL,
+  domain_id     INTEGER NOT NULL DEFAULT 1,
+  biller_id     INTEGER NOT NULL DEFAULT 0,
+  customer_id   INTEGER NOT NULL DEFAULT 0,
+  type_id       INTEGER NOT NULL DEFAULT 0,
+  preference_id INTEGER NOT NULL DEFAULT 0,
+  date          TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  custom_field1 TEXT DEFAULT NULL,
+  custom_field2 TEXT DEFAULT NULL,
+  custom_field3 TEXT DEFAULT NULL,
+  custom_field4 TEXT DEFAULT NULL,
+  note          TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_invoices_pk         ON si_invoices (domain_id, id);
+CREATE INDEX IF NOT EXISTS si_invoices_domain_id          ON si_invoices (domain_id);
+CREATE INDEX IF NOT EXISTS si_invoices_biller_id          ON si_invoices (biller_id);
+CREATE INDEX IF NOT EXISTS si_invoices_customer_id        ON si_invoices (customer_id);
+CREATE UNIQUE INDEX IF NOT EXISTS si_invoices_uniq_dib    ON si_invoices (index_id, preference_id, biller_id, domain_id);
+CREATE INDEX IF NOT EXISTS si_invoices_idx_di             ON si_invoices (index_id, preference_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_log (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id INTEGER NOT NULL DEFAULT 1,
+  timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+  userid    INTEGER NOT NULL DEFAULT 1,
+  sqlquerie TEXT NOT NULL,
+  last_id   INTEGER DEFAULT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_log_pk ON si_log (id, domain_id);
+
+CREATE TABLE IF NOT EXISTS si_payment (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  ac_inv_id         INTEGER NOT NULL,
+  ac_amount         REAL NOT NULL,
+  ac_notes          TEXT NOT NULL,
+  ac_date           TEXT NOT NULL,
+  ac_payment_type   INTEGER NOT NULL DEFAULT 1,
+  domain_id         INTEGER NOT NULL,
+  online_payment_id TEXT DEFAULT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_payment_pk         ON si_payment (domain_id, id);
+CREATE INDEX IF NOT EXISTS si_payment_domain_id          ON si_payment (domain_id);
+CREATE INDEX IF NOT EXISTS si_payment_ac_inv_id          ON si_payment (ac_inv_id);
+CREATE INDEX IF NOT EXISTS si_payment_ac_amount          ON si_payment (ac_amount);
+
+CREATE TABLE IF NOT EXISTS si_payment_types (
+  pt_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id      INTEGER NOT NULL DEFAULT 1,
+  pt_description TEXT NOT NULL,
+  pt_enabled     INTEGER NOT NULL DEFAULT 1
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_payment_types_pk ON si_payment_types (domain_id, pt_id);
+
+CREATE TABLE IF NOT EXISTS si_preferences (
+  pref_id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id                  INTEGER NOT NULL DEFAULT 1,
+  pref_description           TEXT DEFAULT NULL,
+  pref_currency_sign         TEXT DEFAULT NULL,
+  pref_inv_heading           TEXT DEFAULT NULL,
+  pref_inv_wording           TEXT DEFAULT NULL,
+  pref_inv_detail_heading    TEXT DEFAULT NULL,
+  pref_inv_detail_line       TEXT,
+  pref_inv_payment_method    TEXT DEFAULT NULL,
+  pref_inv_payment_line1_name  TEXT DEFAULT NULL,
+  pref_inv_payment_line1_value TEXT DEFAULT NULL,
+  pref_inv_payment_line2_name  TEXT DEFAULT NULL,
+  pref_inv_payment_line2_value TEXT DEFAULT NULL,
+  pref_enabled               INTEGER NOT NULL DEFAULT 1,
+  status                     INTEGER NOT NULL,
+  locale                     TEXT DEFAULT NULL,
+  language                   TEXT DEFAULT NULL,
+  index_group                INTEGER NOT NULL,
+  currency_code              TEXT DEFAULT NULL,
+  include_online_payment     TEXT DEFAULT NULL,
+  currency_position          TEXT DEFAULT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_preferences_pk ON si_preferences (domain_id, pref_id);
+
+CREATE TABLE IF NOT EXISTS si_products (
+  id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id            INTEGER NOT NULL DEFAULT 1,
+  description          TEXT NOT NULL,
+  unit_price           REAL DEFAULT 0,
+  default_tax_id       INTEGER DEFAULT NULL,
+  default_tax_id_2     INTEGER DEFAULT NULL,
+  cost                 REAL DEFAULT 0,
+  reorder_level        INTEGER DEFAULT NULL,
+  custom_field1        TEXT DEFAULT NULL,
+  custom_field2        TEXT DEFAULT NULL,
+  custom_field3        TEXT DEFAULT NULL,
+  custom_field4        TEXT DEFAULT NULL,
+  notes                TEXT DEFAULT NULL,
+  enabled              INTEGER NOT NULL DEFAULT 1,
+  visible              INTEGER NOT NULL DEFAULT 1,
+  attribute            TEXT DEFAULT NULL,
+  notes_as_description TEXT DEFAULT NULL,
+  show_description     TEXT DEFAULT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_products_pk ON si_products (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_products_attribute_type (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS si_products_attributes (
+  id      INTEGER PRIMARY KEY AUTOINCREMENT,
+  name    TEXT NOT NULL,
+  type_id TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  visible INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS si_products_values (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  attribute_id INTEGER NOT NULL,
+  value        TEXT NOT NULL,
+  enabled      INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS si_sql_patchmanager (
+  sql_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  sql_patch_ref INTEGER NOT NULL,
+  sql_patch     TEXT DEFAULT NULL,
+  sql_release   TEXT DEFAULT NULL,
+  sql_statement TEXT DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS si_system_defaults (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  name         TEXT NOT NULL,
+  value        TEXT DEFAULT NULL,
+  domain_id    INTEGER NOT NULL DEFAULT 0,
+  extension_id INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (domain_id, name)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_system_defaults_pk ON si_system_defaults (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_tax (
+  tax_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  tax_description TEXT DEFAULT NULL,
+  tax_percentage  REAL DEFAULT 0,
+  type            TEXT NOT NULL DEFAULT '%',
+  tax_enabled     INTEGER NOT NULL DEFAULT 1,
+  domain_id       INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_tax_pk ON si_tax (domain_id, tax_id);
+
+CREATE TABLE IF NOT EXISTS si_user (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  email     TEXT DEFAULT NULL,
+  name      TEXT DEFAULT NULL,
+  role_id   INTEGER DEFAULT NULL,
+  domain_id INTEGER NOT NULL DEFAULT 0,
+  password  TEXT DEFAULT NULL,
+  enabled   INTEGER NOT NULL DEFAULT 1,
+  user_id   INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (email)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS si_user_pk ON si_user (domain_id, id);
+
+CREATE TABLE IF NOT EXISTS si_user_domain (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  UNIQUE (name)
+);
+
+CREATE TABLE IF NOT EXISTS si_user_role (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  UNIQUE (name)
+);

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -1,0 +1,60 @@
+# PostgreSQL override for Simple Invoices
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up
+#
+# Or set in your shell:
+#   export COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml
+#   docker compose up
+#
+# Required environment variables (add to your .env file):
+#   POSTGRES_PASSWORD=yourpassword
+#   POSTGRES_DB=simple_invoices
+#   POSTGRES_USER=siuser
+#   SI_DB_USER=siuser
+#   SI_DB_PASSWORD=yourpassword
+#   SI_DB_NAME=simple_invoices
+
+services:
+  simpleinvoices:
+    depends_on:
+      db:
+        condition: service_healthy
+        required: true
+    environment:
+      - SI_DATABASE_ADAPTER=pdo_pgsql
+      - SI_DB_HOST=db
+      - SI_DB_PORT=${SI_DB_PORT:-5432}
+      - SI_DB_USER=${SI_DB_USER:-siuser}
+      - SI_DB_PASSWORD=${SI_DB_PASSWORD:-sipassword}
+      - SI_DB_NAME=${SI_DB_NAME:-simple_invoices}
+
+  # Replace MariaDB with PostgreSQL
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-sipassword}
+      POSTGRES_DB: ${POSTGRES_DB:-simple_invoices}
+      POSTGRES_USER: ${POSTGRES_USER:-siuser}
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    volumes:
+      - pgsql_data:/var/lib/postgresql/data
+    networks:
+      - simpleinvoices-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-siuser} -d ${POSTGRES_DB:-simple_invoices}"]
+      start_period: 20s
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Adminer works with PostgreSQL — just point it at the pgsql db service
+  adminer:
+    environment:
+      ADMINER_DEFAULT_SERVER: db
+      ADMINER_DEFAULT_USERNAME: ${POSTGRES_USER:-siuser}
+      ADMINER_DEFAULT_PASSWORD: ${POSTGRES_PASSWORD:-sipassword}
+
+volumes:
+  pgsql_data:

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -1,0 +1,36 @@
+# SQLite override for Simple Invoices
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.sqlite.yml up
+#
+# Or set in your shell:
+#   export COMPOSE_FILE=docker-compose.yml:docker-compose.sqlite.yml
+#   docker compose up
+#
+# The SQLite database file is stored in the named volume 'sqlite_data'
+# which is mounted at /var/www/html/databases/sqlite inside the container.
+# The filename is controlled by SI_DB_NAME (default: simple_invoices).
+
+services:
+  simpleinvoices:
+    environment:
+      - SI_DATABASE_ADAPTER=pdo_sqlite
+      - SI_DB_NAME=${SI_DB_NAME:-simple_invoices}
+      # Clear host/port/credentials — not used by SQLite
+      - SI_DB_HOST=
+      - SI_DB_PORT=
+      - SI_DB_USER=
+      - SI_DB_PASSWORD=
+    volumes:
+      - sqlite_data:/var/www/html/databases/sqlite
+
+  # Disable the MariaDB service
+  db:
+    profiles: ["_disabled_"]
+
+  # Disable Adminer (no SQL server to connect to for SQLite)
+  adminer:
+    profiles: ["_disabled_"]
+
+volumes:
+  sqlite_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
+        required: false   # set to false for SQLite or external PostgreSQL
+    volumes:
+      - sqlite_data:/var/www/html/databases/sqlite
     environment:
       - SI_DB_HOST=${SI_DB_HOST}
       - SI_DB_PORT=${SI_DB_PORT}
@@ -99,6 +102,7 @@ services:
 
 volumes:
   mysql_data:
+  sqlite_data:
 
 networks:
   simpleinvoices-net:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,8 +9,16 @@ mkdir -p /var/www/html/tmp/cache /var/www/html/tmp/log /var/www/html/tmp/databas
 chown -R www-data:www-data /var/www/html/tmp
 chmod -R 775 /var/www/html/tmp
 
-# When running in Docker Compose (or --env-file), override DB config so the app connects to the db
-if [ -n "${SI_DB_HOST}" ]; then
+# For SQLite: ensure the database directory exists and is writable by the web server
+if [ "${SI_DATABASE_ADAPTER:-pdo_mysql}" = "pdo_sqlite" ]; then
+  mkdir -p /var/www/html/databases/sqlite
+  chown -R www-data:www-data /var/www/html/databases/sqlite
+  chmod 775 /var/www/html/databases/sqlite
+fi
+
+# When running in Docker Compose (or --env-file), override DB config so the app connects to the db.
+# SQLite has no network host; skip the host-resolution wait for it.
+if [ -n "${SI_DB_HOST}" ] && [ "${SI_DATABASE_ADAPTER:-pdo_mysql}" != "pdo_sqlite" ]; then
   # Single PHP process that waits for host resolution (avoids 30x php invocations)
   _port="${SI_DB_PORT:-3306}"
   _max="${SI_DB_WAIT_MAX:-30}"

--- a/include/auth/password.php
+++ b/include/auth/password.php
@@ -69,27 +69,23 @@ function auth_needs_rehash($storedHash)
  */
 /**
  * Detect which user table schema variant is present.
- * Returns 'modern' (email + user_id cols), 'legacy' (user_email cols), or 'oldest' (si_users table).
+ * Returns 'modern' (email + user_id cols), 'mid' (email only), 'legacy' (user_email cols), or 'oldest'.
+ * Uses checkFieldExists() so it works with MySQL, PostgreSQL, and SQLite.
  */
 function auth_detect_schema()
 {
-    global $dbh;
-
     // Modern schema: si_user with 'email' and 'user_id' columns (post-patch 292)
-    $sth = $dbh->query("SHOW COLUMNS FROM " . TB_PREFIX . "user LIKE 'user_id'");
-    if ($sth && $sth->fetch()) {
+    if (checkFieldExists(TB_PREFIX . 'user', 'user_id')) {
         return 'modern';
     }
 
     // Mid schema: si_user with 'email' column but no 'user_id' (post-patch 184)
-    $sth = $dbh->query("SHOW COLUMNS FROM " . TB_PREFIX . "user LIKE 'email'");
-    if ($sth && $sth->fetch()) {
+    if (checkFieldExists(TB_PREFIX . 'user', 'email')) {
         return 'mid';
     }
 
     // Legacy schema: si_user with 'user_email' column (post-patch 147)
-    $sth = $dbh->query("SHOW COLUMNS FROM " . TB_PREFIX . "user LIKE 'user_email'");
-    if ($sth && $sth->fetch()) {
+    if (checkFieldExists(TB_PREFIX . 'user', 'user_email')) {
         return 'legacy';
     }
 
@@ -100,12 +96,14 @@ function auth_detect_schema()
 function auth_authenticate_user($email, $password)
 {
     // Upgrade a stored hash to bcrypt if it is MD5 or if bcrypt cost has changed.
-    $upgradeHash = static function (string $id, string $plainPassword): void {
+    // domain_id is included in the WHERE to scope the update to the correct tenant row.
+    $upgradeHash = static function (string $id, string $domain_id, string $plainPassword): void {
         $newHash = auth_hash_password($plainPassword);
         dbQuery(
-            "UPDATE " . TB_PREFIX . "user SET password = :password WHERE id = :id",
+            "UPDATE " . TB_PREFIX . "user SET password = :password WHERE id = :id AND domain_id = :domain_id",
             ':password', $newHash,
-            ':id', $id
+            ':id', $id,
+            ':domain_id', $domain_id
         );
     };
 
@@ -123,7 +121,7 @@ function auth_authenticate_user($email, $password)
         $row = $sth ? $sth->fetch(PDO::FETCH_ASSOC) : false;
         if ($row && auth_verify_password($password, $row['password'])) {
             if (auth_needs_rehash($row['password'])) {
-                $upgradeHash($row['id'], $password);
+                $upgradeHash($row['id'], $row['domain_id'], $password);
             }
             unset($row['password']);
             return $row;
@@ -143,7 +141,7 @@ function auth_authenticate_user($email, $password)
         $row = $sth ? $sth->fetch(PDO::FETCH_ASSOC) : false;
         if ($row && auth_verify_password($password, $row['password'])) {
             if (auth_needs_rehash($row['password'])) {
-                $upgradeHash($row['id'], $password);
+                $upgradeHash($row['id'], $row['domain_id'], $password);
             }
             unset($row['password']);
             $row['user_id'] = 0;

--- a/include/class/cron.php
+++ b/include/class/cron.php
@@ -99,6 +99,7 @@ class cron {
     public function select_all($type='', $dir='DESC', $rp='25', $page='1')
 	{
 		global $LANG;
+		global $db_server;
 		$valid_search_fields = array('iv.id', 'b.name', 'cron.id', 'aging');
 
 		/*SQL Limit - start*/
@@ -173,8 +174,9 @@ class cron {
 
     public function select_crons_to_run()
     {
-        global \$db_server;
+        global $db_server;
         // Use this function to select crons that need to run each day across all domain_id values
+        $cron_index_expr = ($db_server === 'mysql') ? "(SELECT CONCAT(pf.pref_description,' ',iv.index_id))" : "(pf.pref_description || ' ' || CAST(iv.index_id AS TEXT))";
 
         $sql = "SELECT
                   cron.*
@@ -198,8 +200,9 @@ class cron {
 
 	public function select()
 	{
-		global \$db_server;
+		global $db_server;
 		global $LANG;
+		$cron_index_expr = ($db_server === 'mysql') ? "(SELECT CONCAT(pf.pref_description,' ',iv.index_id))" : "(pf.pref_description || ' ' || CAST(iv.index_id AS TEXT))";
 
 		$sql = "SELECT
 				cron.*

--- a/include/class/cron.php
+++ b/include/class/cron.php
@@ -110,8 +110,8 @@ class cron {
 		/*SQL where - start*/
 
 		$where = "";
-		$query = isset($_POST['query']) ? $_POST['query'] : null;
-		$qtype = isset($_POST['qtype']) ? $_POST['qtype'] : null;
+		$query = $_POST['query'] ?? null;
+		$qtype = $_POST['qtype'] ?? null;
 		if ( ! (empty($qtype) || empty($query)) ) {
 			if ( in_array($qtype, $valid_search_fields) ) {
 				$where = " AND $qtype LIKE :query ";

--- a/include/class/cron.php
+++ b/include/class/cron.php
@@ -103,7 +103,7 @@ class cron {
 
 		/*SQL Limit - start*/
 		$start = (($page-1) * $rp);
-		$limit = "LIMIT ".$start.", ".$rp;
+		$limit = "LIMIT ".$rp." OFFSET ".$start;
 		/*SQL Limit - end*/
 
 		/*SQL where - start*/
@@ -137,10 +137,11 @@ class cron {
 		}
 
 
+		$cron_index_expr = ($db_server === 'mysql') ? "(SELECT CONCAT(pf.pref_description,' ',iv.index_id))" : "(pf.pref_description || ' ' || CAST(iv.index_id AS TEXT))";
 		$sql = "SELECT
 				cron.*
                 , cron.id as cron_id
-                , (SELECT CONCAT(pf.pref_description,' ',iv.index_id)) as index_name
+                , $cron_index_expr as index_name
 			FROM 
 				".TB_PREFIX."cron cron 
 				INNER JOIN ".TB_PREFIX."invoices iv 
@@ -172,12 +173,13 @@ class cron {
 
     public function select_crons_to_run()
     {
+        global \$db_server;
         // Use this function to select crons that need to run each day across all domain_id values
 
         $sql = "SELECT
                   cron.*
                 , cron.id as cron_id
-                , (SELECT CONCAT(pf.pref_description,' ',iv.index_id)) as index_name
+                , $cron_index_expr as index_name
             FROM 
                 ".TB_PREFIX."cron cron 
                 INNER JOIN ".TB_PREFIX."invoices iv 
@@ -196,11 +198,12 @@ class cron {
 
 	public function select()
 	{
+		global \$db_server;
 		global $LANG;
 
 		$sql = "SELECT
 				cron.*
-                , (SELECT CONCAT(pf.pref_description,' ',iv.index_id)) as index_name
+                , $cron_index_expr as index_name
 			FROM 
 				".TB_PREFIX."cron cron 
 				INNER JOIN ".TB_PREFIX."invoices iv 

--- a/include/class/db.php
+++ b/include/class/db.php
@@ -13,71 +13,87 @@ class db
 
 		global $config;
         //check if PDO is availbel
-        
+
         class_exists('PDO',false) ? "" : simpleInvoicesError("PDO");
 		/*
 		* strip the pdo_ section from the adapter
 		*/
 		$pdoAdapter = substr($config->database->adapter, 4);
-		
+
 		if(!defined('PDO::MYSQL_ATTR_INIT_COMMAND') AND $pdoAdapter == "mysql" AND $config->database->utf8 == true)
-		{ 
+		{
             simpleInvoicesError("PDO_mysql_attr");
 		}
 
 		try
 		{
-			
-			switch ($pdoAdapter) 
+
+			switch ($pdoAdapter)
 			{
 
 			    case "pgsql":
+			    	$port = !empty($config->database->params->port) ? ';port='.$config->database->params->port : '';
 			    	$this->_db = new PDO(
-						$pdoAdapter.':host='.$config->database->params->host.';	dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
+						'pgsql:host='.$config->database->params->host.$port.';dbname='.$config->database->params->dbname,
+						$config->database->params->username,
+						$config->database->params->password
 					);
+					$this->_db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			    	break;
-			    	
+
 			    case "sqlite":
-			    	$connlink = new PDO(
-						$pdoAdapter.':host='.$config->database->params->host.';	dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
-					);
+			    	$dsn = $config->database->params->dbname;
+			    	// If not an absolute path or :memory:, resolve relative to databases/sqlite/
+			    	if ($dsn !== ':memory:' && (strlen($dsn) === 0 || $dsn[0] !== '/')) {
+			    		$base = preg_replace('/\.sqlite$/', '', $dsn);
+			    		$dir  = realpath('.') . '/databases/sqlite';
+			    		if (!is_dir($dir)) {
+			    			mkdir($dir, 0755, true);
+			    		}
+			    		$dsn = $dir . '/' . $base . '.sqlite';
+			    	}
+			    	$this->_db = new PDO('sqlite:' . $dsn);
+					$this->_db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+					// WAL mode for better concurrency; enforce FK constraints
+					$this->_db->exec('PRAGMA journal_mode=WAL');
+					$this->_db->exec('PRAGMA foreign_keys=ON');
 					break;
-				
+
                 case "mysql":
                     switch ($config->database->utf8)
                     {
                         case true:
-        
+
                             $this->_db = new PDO(
-                                'mysql:host='.$config->database->params->host.'; port='.$config->database->params->port.'; dbname='.$config->database->params->dbname, $config->database->params->username, $config->database->params->password,  array( PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8;")
+                                'mysql:host='.$config->database->params->host.';port='.$config->database->params->port.';dbname='.$config->database->params->dbname, $config->database->params->username, $config->database->params->password,  array( PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8;")
                             );
 				$this->_db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
                             break;
-                    
+
                         case false:
                             $this->_db = new PDO(
-                                $pdoAdapter.':host='.$config->database->params->host.'; port='.$config->database->params->port.'; dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
+                                'mysql:host='.$config->database->params->host.';port='.$config->database->params->port.';dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
                             );
                         break;
                     }
                     break;
 			}
-			
 
-			
+
+
 		}
 		catch( PDOException $exception )
 		{
 			simpleInvoicesError("dbConnection",$exception->getMessage());
 			die($exception->getMessage());
 		}
-			
-	
+
+
 		//return $this->connnection;
-		
-		
+
+
 	}
-	
+
     //private __clone() {};
 
     public static function getInstance()
@@ -86,16 +102,16 @@ class db
         {
             self::$_instance = new self();
         }
-		
-		  return self::$_instance; 
+
+		  return self::$_instance;
     }
-    
+
 
 	function query($sqlQuery)
 	{
 		//dbQuery($sql);
-		
-		try {	
+
+		try {
 		//$dbh = $this->connection;
 		//var_dump($this->_db);
 		$argc = func_num_args();
@@ -109,8 +125,8 @@ class db
 				$sth->bindValue($binds[$i], $binds[++$i]);
 			}
 		}
-		
-				
+
+
 			//var_dump($this->_db);
 			$result = $sth->execute();
 			//$sth->closeCursor();
@@ -128,9 +144,9 @@ class db
 		#return $result;
 
 		$sth->closeCursor();
-		
+
 		$sth = NULL;
-			
+
 	}
     /*
      * lastInsertId returns the id of the most recently inserted row by the session
@@ -142,22 +158,27 @@ class db
     function lastInsertId() {
         global $config;
         $pdoAdapter = substr($config->database->adapter, 4);
-        
+
         if ($pdoAdapter == 'pgsql') {
             $sql = 'SELECT lastval()';
-        } elseif ($pdoAdapter == 'mysql') {
+            $sth = $this->query($sql);
+            return $sth->fetchColumn();
+        } elseif ($pdoAdapter == 'sqlite') {
+            // PDO::lastInsertId() works natively for SQLite
+            return $this->_db->lastInsertId();
+        } else {
+            // MySQL
             $sql = 'SELECT last_insert_id()';
+            $sth = $this->query($sql);
+            return $sth->fetchColumn();
         }
-        //echo $sql;
-        $sth = $this->query($sql);
-        return $sth->fetchColumn();
     }
 
-	
-	function __destruct() 
+
+	function __destruct()
 	{
 	//$this->connection->closeCursor();
 	 //$this->connection = null;
 	}
-	
+
 }

--- a/include/class/inventory.php
+++ b/include/class/inventory.php
@@ -83,8 +83,8 @@ class inventory {
 
 		/*SQL where - start*/
 		$where = "";
-		$query = isset($_POST['query']) ? $_POST['query'] : null;
-		$qtype = isset($_POST['qtype']) ? $_POST['qtype'] : null;
+		$query = $_POST['query'] ?? null;
+		$qtype = $_POST['qtype'] ?? null;
 		if ( ! (empty($qtype) || empty($query)) ) {
 			if ( in_array($qtype, $valid_search_fields) ) {
 				$where = " AND $qtype LIKE :query ";

--- a/include/class/inventory.php
+++ b/include/class/inventory.php
@@ -78,7 +78,7 @@ class inventory {
 
 		/*SQL Limit - start*/
 		$start = (($page-1) * $rp);
-		$limit = " LIMIT $start, $rp";
+		$limit = " LIMIT $rp OFFSET $start";
 		/*SQL Limit - end*/
 
 		/*SQL where - start*/

--- a/include/class/invoice.php
+++ b/include/class/invoice.php
@@ -157,13 +157,18 @@ class invoice {
     public function select($id, $domain_id='')
     {
 		global $logger;
+		global $db_server;
 
 		if(!empty($domain_id)) $this->domain_id = $domain_id;
 
-		$sql = "SELECT 
+		$index_name_expr = ($db_server === 'mysql')
+			? "(SELECT CONCAT(p.pref_inv_wording,' ',i.index_id))"
+			: "(p.pref_inv_wording || ' ' || CAST(i.index_id AS TEXT))";
+
+		$sql = "SELECT
                     i.*,
-		            i.date as date_original, 
-                    (SELECT CONCAT(p.pref_inv_wording,' ',i.index_id)) as index_name,
+		            i.date as date_original,
+                    $index_name_expr as index_name,
                     p.pref_inv_wording AS preference,
                     p.status
                 FROM 
@@ -204,12 +209,17 @@ class invoice {
     public function get_all($domain_id='')
     {
 		global $logger;
+		global $db_server;
 
 		$domain_id = domain_id::get($domain_id);
 
-		$sql = "SELECT 
+		$index_name_expr = ($db_server === 'mysql')
+			? "(SELECT CONCAT(p.pref_inv_wording,' ',i.index_id))"
+			: "(p.pref_inv_wording || ' ' || CAST(i.index_id AS TEXT))";
+
+		$sql = "SELECT
                     i.id as id,
-                    (SELECT CONCAT(p.pref_inv_wording,' ',i.index_id)) as index_name
+                    $index_name_expr as index_name
                 FROM 
                     ".TB_PREFIX."invoices i LEFT JOIN 
 					".TB_PREFIX."preferences p  
@@ -254,7 +264,7 @@ class invoice {
 
         /*SQL Limit - start*/
         $start = (($page-1) * $rp);
-        $limit = "LIMIT ".$start.", ".$rp;
+        $limit = "LIMIT ".$rp." OFFSET ".$start;
         /*SQL Limit - end*/
 
 
@@ -330,92 +340,125 @@ class invoice {
                 break;
         }
 
+        global $db_server;
+
         switch ($config->database->adapter)
         {
             case "pdo_pgsql":
-               $sql = "
+                $sql = "
                 SELECT
                      iv.id,
-                     iv.index_id as index_id,
-                     b.name AS Biller,
-                     c.name AS Customer,
-                     sum(ii.total) AS INV_TOTAL,
-                     coalesce(SUM(ap.ac_amount), 0)  AS INV_PAID,
-                     (SUM(ii.total) - coalesce(sum(ap.ac_amount), 0)) AS INV_OWING ,
-                     to_char(date,'YYYY-MM-DD') AS Date ,
-                     (SELECT now()::date - iv.date) AS Age,
-                     (CASE WHEN now()::date - iv.date <= '14 days'::interval THEN '0-14'
-                      WHEN now()::date - iv.date <= '30 days'::interval THEN '15-30'
-                      WHEN now()::date - iv.date <= '60 days'::interval THEN '31-60'
-                      WHEN now()::date - iv.date <= '90 days'::interval THEN '61-90'
-                      ELSE '90+'
-                     END) AS Aging,
-                     iv.type_id As type_id,
-                     p.pref_description AS `type`,
-                     p.pref_inv_wording AS invoice_wording
-                FROM
-                     " . TB_PREFIX . "invoices iv
-                     LEFT JOIN " . TB_PREFIX . "payment ap       ON ap.ac_inv_id = iv.id
-                     LEFT JOIN " . TB_PREFIX . "invoice_items ii ON ii.invoice_id = iv.id
-                     LEFT JOIN " . TB_PREFIX . "biller b         ON b.id = iv.biller_id
-                     LEFT JOIN " . TB_PREFIX . "customers c      ON c.id = iv.customer_id
-                     LEFT JOIN " . TB_PREFIX . "preferences p    ON p.pref_id = iv.preference_id
-				WHERE iv.domain_id = :domain_id 
-					$where
+                     iv.index_id AS index_id,
+                     b.name AS biller,
+                     c.name AS customer,
+                     COALESCE(SUM(ii.total), 0) AS invoice_total,
+                     COALESCE(SUM(ap.ac_amount), 0) AS INV_PAID,
+                     (COALESCE(SUM(ii.total), 0) - COALESCE(SUM(ap.ac_amount), 0)) AS owing,
+                     TO_CHAR(iv.date, 'YYYY-MM-DD') AS date,
+                     EXTRACT(day FROM (now() - iv.date::timestamp))::int AS Age,
+                     (CASE WHEN EXTRACT(day FROM (now() - iv.date::timestamp))::int <= 0 THEN ''
+                           WHEN EXTRACT(day FROM (now() - iv.date::timestamp))::int <= 30 THEN '0-30'
+                           WHEN EXTRACT(day FROM (now() - iv.date::timestamp))::int <= 60 THEN '31-60'
+                           WHEN EXTRACT(day FROM (now() - iv.date::timestamp))::int <= 90 THEN '61-90'
+                           ELSE '90+'
+                     END) AS aging,
+                     iv.type_id AS type_id,
+                     pf.pref_description AS preference,
+                     pf.status AS status,
+                     (pf.pref_inv_wording || ' ' || CAST(iv.index_id AS TEXT)) AS index_name
+                FROM " . TB_PREFIX . "invoices iv
+                     LEFT JOIN " . TB_PREFIX . "payment ap       ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "biller b         ON (b.id = iv.biller_id AND b.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "customers c      ON (c.id = iv.customer_id AND c.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "preferences pf   ON (pf.pref_id = iv.preference_id AND pf.domain_id = iv.domain_id)
+                WHERE iv.domain_id = :domain_id
+                    $where
                 GROUP BY
-                    iv.id, b.name, c.name, Date, Age, Aging, `type`
-                ORDER BY
-                    $sort $dir
-                LIMIT $limit OFFSET $start";
+                    iv.id, iv.index_id, b.name, c.name, iv.date, iv.type_id, pf.pref_description, pf.status, pf.pref_inv_wording
+                $sql_having
+                ORDER BY $sort $dir
+                $limit";
                 break;
+
+            case "pdo_sqlite":
+                $sql = "
+                SELECT
+                     iv.id,
+                     iv.index_id AS index_id,
+                     b.name AS biller,
+                     c.name AS customer,
+                     COALESCE(SUM(ii.total), 0) AS invoice_total,
+                     COALESCE(SUM(ap.ac_amount), 0) AS INV_PAID,
+                     (COALESCE(SUM(ii.total), 0) - COALESCE(SUM(ap.ac_amount), 0)) AS owing,
+                     strftime('%Y-%m-%d', iv.date) AS date,
+                     CAST(julianday('now') - julianday(iv.date) AS INTEGER) AS Age,
+                     (CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 0 THEN ''
+                           WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '0-30'
+                           WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
+                           WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
+                           ELSE '90+'
+                     END) AS aging,
+                     iv.type_id AS type_id,
+                     pf.pref_description AS preference,
+                     pf.status AS status,
+                     (pf.pref_inv_wording || ' ' || CAST(iv.index_id AS TEXT)) AS index_name
+                FROM " . TB_PREFIX . "invoices iv
+                     LEFT JOIN " . TB_PREFIX . "payment ap       ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "biller b         ON (b.id = iv.biller_id AND b.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "customers c      ON (c.id = iv.customer_id AND c.domain_id = iv.domain_id)
+                     LEFT JOIN " . TB_PREFIX . "preferences pf   ON (pf.pref_id = iv.preference_id AND pf.domain_id = iv.domain_id)
+                WHERE iv.domain_id = :domain_id
+                    $where
+                GROUP BY
+                    iv.id, iv.index_id, b.name, c.name, iv.date, iv.type_id, pf.pref_description, pf.status, pf.pref_inv_wording
+                $sql_having
+                ORDER BY $sort $dir
+                $limit";
+                break;
+
             case "pdo_mysql":
             default:
-                $sql ="
-                    SELECT  
+                $sql = "
+                    SELECT
                        iv.id,
-                       iv.index_id as index_id,
+                       iv.index_id AS index_id,
                        b.name AS biller,
                        c.name AS customer,
-                       DATE_FORMAT(date,'%Y-%m-%d') AS date,";
+                       DATE_FORMAT(iv.date,'%Y-%m-%d') AS date,
+                       (SELECT COALESCE(SUM(ii.total), 0) FROM " . TB_PREFIX . "invoice_items ii WHERE ii.invoice_id = iv.id AND ii.domain_id = :domain_id) AS invoice_total,
+                       (SELECT COALESCE(SUM(ac_amount), 0) FROM " . TB_PREFIX . "payment ap WHERE ap.ac_inv_id = iv.id AND ap.domain_id = :domain_id) AS INV_PAID,
+                       (SELECT invoice_total - INV_PAID) AS owing,";
 
-                $sql .="(SELECT coalesce(SUM(ii.total), 0) FROM " .
-                TB_PREFIX . "invoice_items ii WHERE ii.invoice_id = iv.id AND ii.domain_id = :domain_id) AS invoice_total,
-                       (SELECT coalesce(SUM(ac_amount), 0) FROM " .
-                TB_PREFIX . "payment ap WHERE ap.ac_inv_id = iv.id AND ap.domain_id = :domain_id) AS INV_PAID,
-                       (SELECT invoice_total - INV_PAID) As owing,
-                       ";
-
-              //only run aging for real full query ($type is empty for full query or count for count query)
-                if($type == '')
-                {
-                    $sql .="
-                       (SELECT IF((owing <= 0 OR DateDiff(now(), date) < 0), 0, DateDiff(now(), date))) AS Age,
-                       (SELECT (CASE WHEN Age <= 0 THEN ''
-                                     WHEN Age <= 30 THEN '0-30'
-                                     WHEN Age <= 60 THEN '31-60'
-                                     WHEN Age <= 90 THEN '61-90'
-                                     ELSE '90+'  END)) AS aging,";
+                if ($type == '') {
+                    $sql .= "
+                       (SELECT CASE WHEN (owing <= 0 OR DATEDIFF(NOW(), iv.date) < 0) THEN 0 ELSE DATEDIFF(NOW(), iv.date) END) AS Age,
+                       (SELECT CASE WHEN Age <= 0 THEN ''
+                                    WHEN Age <= 30 THEN '0-30'
+                                    WHEN Age <= 60 THEN '31-60'
+                                    WHEN Age <= 90 THEN '61-90'
+                                    ELSE '90+' END) AS aging,";
                 } else {
-                    $sql .="
-                        '' as Age,
-                        '' as aging,
-                        ";
+                    $sql .= "
+                        '' AS Age,
+                        '' AS aging,";
                 }
-                $sql .="iv.type_id As type_id,
+                $sql .= "
+                       iv.type_id AS type_id,
                        pf.pref_description AS preference,
                        pf.status AS status,
-                       (SELECT CONCAT(pf.pref_inv_wording,' ',iv.index_id)) as index_name
-                FROM   " . TB_PREFIX . "invoices iv
-                               LEFT JOIN " . TB_PREFIX . "biller b       ON (b.id = iv.biller_id           AND b.domain_id  = iv.domain_id)
-                               LEFT JOIN " . TB_PREFIX . "customers c    ON (c.id = iv.customer_id         AND c.domain_id  = iv.domain_id)
-                               LEFT JOIN " . TB_PREFIX . "preferences pf ON (pf.pref_id = iv.preference_id AND pf.domain_id = iv.domain_id)
+                       (SELECT CONCAT(pf.pref_inv_wording,' ',iv.index_id)) AS index_name
+                FROM " . TB_PREFIX . "invoices iv
+                    LEFT JOIN " . TB_PREFIX . "biller b       ON (b.id = iv.biller_id           AND b.domain_id  = iv.domain_id)
+                    LEFT JOIN " . TB_PREFIX . "customers c    ON (c.id = iv.customer_id         AND c.domain_id  = iv.domain_id)
+                    LEFT JOIN " . TB_PREFIX . "preferences pf ON (pf.pref_id = iv.preference_id AND pf.domain_id = iv.domain_id)
                 WHERE iv.domain_id = :domain_id
-					$where
+                    $where
                 GROUP BY
                     iv.id
-				$sql_having
-                ORDER BY
-					$sort $dir
+                $sql_having
+                ORDER BY $sort $dir
                 $limit";
                 break;
         }

--- a/include/class/product.php
+++ b/include/class/product.php
@@ -69,8 +69,8 @@ class product
         }
 
 		$where = "";
-		$query = isset($_POST['query']) ? $_POST['query'] : null;
-		$qtype = isset($_POST['qtype']) ? $_POST['qtype'] : null;
+		$query = $_POST['query'] ?? null;
+		$qtype = $_POST['qtype'] ?? null;
 		if ( ! (empty($qtype) || empty($query)) ) {
 			if ( in_array($qtype, $valid_search_fields) ) {
 				$where = " AND $qtype LIKE :query ";

--- a/include/class/product.php
+++ b/include/class/product.php
@@ -56,7 +56,7 @@ class product
         }
         /*SQL Limit - start*/
         $start = (($page-1) * $rp);
-        $limit = "LIMIT $start, $rp";
+        $limit = "LIMIT $rp OFFSET $start";
 
         if($type =="count")
         {

--- a/include/class/system/system_default.php
+++ b/include/class/system/system_default.php
@@ -7,11 +7,12 @@ class system_default {
 		$this->extension_name = "core";
 
 	}
-	
+
 	public function update()
 	{
 
 		global $db;
+		global $db_server;
 		global $auth_session;
 		$domain_id = $auth_session->domain_id;
 
@@ -28,17 +29,18 @@ class system_default {
 			die(htmlsafe("Invalid extension name: ".$extension));
 		}
 
-		$sql = "INSERT INTO 
-			`".TB_PREFIX."system_defaults`
-			(
-				`name`, `value`, domain_id, extension_id
-			)
-			VALUES
-			(
-				:name, :value, :domain_id, :extension_id
-			)
-			ON DUPLICATE KEY UPDATE
-				`value` =  :value";
+		if ($db_server == 'mysql') {
+			$sql = "INSERT INTO `".TB_PREFIX."system_defaults`
+				(`name`, `value`, domain_id, extension_id)
+				VALUES (:name, :value, :domain_id, :extension_id)
+				ON DUPLICATE KEY UPDATE `value` = :value";
+		} else {
+			// PostgreSQL 9.5+ / SQLite 3.24+ upsert syntax
+			$sql = "INSERT INTO ".TB_PREFIX."system_defaults
+				(name, value, domain_id, extension_id)
+				VALUES (:name, :value, :domain_id, :extension_id)
+				ON CONFLICT (domain_id, name) DO UPDATE SET value = EXCLUDED.value";
+		}
 
 		if ($db->query($sql,
 			':value', $value,

--- a/include/functions.php
+++ b/include/functions.php
@@ -21,19 +21,17 @@ function checkLogin() {
 }
 
 function getLogoList() {
-	$dirname="./templates/invoices/logos";
-	$ext = array("jpg", "png", "jpeg", "gif");
-	$files = array();
-	if($handle = opendir($dirname)) {
-		while(false !== ($file = readdir($handle)))
-		for($i=0;$i<sizeof($ext);$i++)
-		if(stristr($file, ".".$ext[$i])) //NOT case sensitive: OK with JpeG, JPG, ecc.
-		$files[] = $file;
-		closedir($handle);
+	$dirname = "./templates/invoices/logos";
+	$allowed = ['jpg', 'png', 'jpeg', 'gif'];
+	$files   = [];
+	if (is_dir($dirname)) {
+		foreach (new DirectoryIterator($dirname) as $fileInfo) {
+			if ($fileInfo->isFile() && in_array(strtolower($fileInfo->getExtension()), $allowed, true)) {
+				$files[] = $fileInfo->getFilename();
+			}
+		}
 	}
-
 	sort($files);
-	
 	return $files;
 }
 
@@ -104,9 +102,9 @@ function dropDown($choiceArray, $defVal) {
 	foreach ($choiceArray as $key => $value)
 	{
 		if ($key == $defVal) {
-			$dropDown .= "\n" . '<OPTION SELECTED style="font-weight: bold" value='.$key.'>'.$value.'</OPTION>';
+			$dropDown .= "\n" . '<option selected style="font-weight: bold" value="'.htmlspecialchars($key, ENT_QUOTES).'">'.$value.'</option>';
 		} else {
-			$dropDown .= "\n" . '<OPTION '.$selected.' value='.$key.'>'.$value.'</OPTION>';
+			$dropDown .= "\n" . '<option value="'.htmlspecialchars($key, ENT_QUOTES).'">'.$value.'</option>';
 		}
 	}
 	$dropDown .= "\n</select>";

--- a/include/init.php
+++ b/include/init.php
@@ -107,6 +107,9 @@ include_once('./include/class/ConfigLoader.php');
 	    $config = ConfigLoader::load('./config/config.php', $environment);
 	}	//added 'true' to allow modifications from db
 
+// Global database adapter type: 'mysql', 'pgsql', or 'sqlite'
+$db_server = substr($config->database->adapter, 4);
+
 //set up app with relevant php setting
 date_default_timezone_set($config->phpSettings->date->timezone);
 $errorReporting = $config->debug->error_reporting;

--- a/include/sql_patches.php
+++ b/include/sql_patches.php
@@ -1712,3 +1712,229 @@ PRIMARY KEY ( `domain_id`, `id` )
     }
     $patch['294']['date']  = "20260331";
 
+    // -------------------------------------------------------------------------
+    // Patches 295-320: Migrate all tables from MyISAM to InnoDB.
+    //
+    // InnoDB requires an AUTO_INCREMENT column to be the leftmost column of at
+    // least one key/index.  For tables with a composite PRIMARY KEY (domain_id, id)
+    // the auto-increment column (id) is NOT leftmost.  Adding KEY (id) satisfies
+    // the InnoDB requirement without altering the composite PK or any query.
+    //
+    // pgsql / sqlite installs record each patch as applied via SELECT 1 (no-op).
+    // -------------------------------------------------------------------------
+
+    // --- Category A: composite PK where auto-increment column is not leftmost --
+
+    $patch['295']['name']  = "Migrate si_biller to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['295']['patch'] = "ALTER TABLE `".TB_PREFIX."biller` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['295']['patch'] = "SELECT 1";
+    }
+    $patch['295']['date']  = "20260408";
+
+    $patch['296']['name']  = "Migrate si_cron to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['296']['patch'] = "ALTER TABLE `".TB_PREFIX."cron` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['296']['patch'] = "SELECT 1";
+    }
+    $patch['296']['date']  = "20260408";
+
+    $patch['297']['name']  = "Migrate si_cron_log to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['297']['patch'] = "ALTER TABLE `".TB_PREFIX."cron_log` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['297']['patch'] = "SELECT 1";
+    }
+    $patch['297']['date']  = "20260408";
+
+    $patch['298']['name']  = "Migrate si_customers to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['298']['patch'] = "ALTER TABLE `".TB_PREFIX."customers` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['298']['patch'] = "SELECT 1";
+    }
+    $patch['298']['date']  = "20260408";
+
+    $patch['299']['name']  = "Migrate si_inventory to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['299']['patch'] = "ALTER TABLE `".TB_PREFIX."inventory` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['299']['patch'] = "SELECT 1";
+    }
+    $patch['299']['date']  = "20260408";
+
+    $patch['300']['name']  = "Migrate si_invoices to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['300']['patch'] = "ALTER TABLE `".TB_PREFIX."invoices` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['300']['patch'] = "SELECT 1";
+    }
+    $patch['300']['date']  = "20260408";
+
+    $patch['301']['name']  = "Migrate si_payment to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['301']['patch'] = "ALTER TABLE `".TB_PREFIX."payment` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['301']['patch'] = "SELECT 1";
+    }
+    $patch['301']['date']  = "20260408";
+
+    $patch['302']['name']  = "Migrate si_payment_types to InnoDB: add KEY pt_id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['302']['patch'] = "ALTER TABLE `".TB_PREFIX."payment_types` ADD KEY `pt_id` (`pt_id`), ENGINE=InnoDB";
+    } else {
+        $patch['302']['patch'] = "SELECT 1";
+    }
+    $patch['302']['date']  = "20260408";
+
+    $patch['303']['name']  = "Migrate si_preferences to InnoDB: add KEY pref_id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['303']['patch'] = "ALTER TABLE `".TB_PREFIX."preferences` ADD KEY `pref_id` (`pref_id`), ENGINE=InnoDB";
+    } else {
+        $patch['303']['patch'] = "SELECT 1";
+    }
+    $patch['303']['date']  = "20260408";
+
+    $patch['304']['name']  = "Migrate si_products to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['304']['patch'] = "ALTER TABLE `".TB_PREFIX."products` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['304']['patch'] = "SELECT 1";
+    }
+    $patch['304']['date']  = "20260408";
+
+    $patch['305']['name']  = "Migrate si_system_defaults to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['305']['patch'] = "ALTER TABLE `".TB_PREFIX."system_defaults` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['305']['patch'] = "SELECT 1";
+    }
+    $patch['305']['date']  = "20260408";
+
+    $patch['306']['name']  = "Migrate si_tax to InnoDB: add KEY tax_id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['306']['patch'] = "ALTER TABLE `".TB_PREFIX."tax` ADD KEY `tax_id` (`tax_id`), ENGINE=InnoDB";
+    } else {
+        $patch['306']['patch'] = "SELECT 1";
+    }
+    $patch['306']['date']  = "20260408";
+
+    $patch['307']['name']  = "Migrate si_user to InnoDB: add KEY id for AUTO_INCREMENT";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['307']['patch'] = "ALTER TABLE `".TB_PREFIX."user` ADD KEY `id` (`id`), ENGINE=InnoDB";
+    } else {
+        $patch['307']['patch'] = "SELECT 1";
+    }
+    $patch['307']['date']  = "20260408";
+
+    // --- Category B: composite PK where auto-increment column is already leftmost --
+    // No KEY needed; ENGINE change only.
+
+    $patch['308']['name']  = "Migrate si_custom_fields to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['308']['patch'] = "ALTER TABLE `".TB_PREFIX."custom_fields` ENGINE=InnoDB";
+    } else {
+        $patch['308']['patch'] = "SELECT 1";
+    }
+    $patch['308']['date']  = "20260408";
+
+    $patch['309']['name']  = "Migrate si_extensions to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['309']['patch'] = "ALTER TABLE `".TB_PREFIX."extensions` ENGINE=InnoDB";
+    } else {
+        $patch['309']['patch'] = "SELECT 1";
+    }
+    $patch['309']['date']  = "20260408";
+
+    $patch['310']['name']  = "Migrate si_log to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['310']['patch'] = "ALTER TABLE `".TB_PREFIX."log` ENGINE=InnoDB";
+    } else {
+        $patch['310']['patch'] = "SELECT 1";
+    }
+    $patch['310']['date']  = "20260408";
+
+    // --- Category C: single-column PK — InnoDB already compatible, ENGINE change only --
+
+    $patch['311']['name']  = "Migrate si_invoice_item_tax to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['311']['patch'] = "ALTER TABLE `".TB_PREFIX."invoice_item_tax` ENGINE=InnoDB";
+    } else {
+        $patch['311']['patch'] = "SELECT 1";
+    }
+    $patch['311']['date']  = "20260408";
+
+    $patch['312']['name']  = "Migrate si_invoice_items to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['312']['patch'] = "ALTER TABLE `".TB_PREFIX."invoice_items` ENGINE=InnoDB";
+    } else {
+        $patch['312']['patch'] = "SELECT 1";
+    }
+    $patch['312']['date']  = "20260408";
+
+    $patch['313']['name']  = "Migrate si_invoice_type to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['313']['patch'] = "ALTER TABLE `".TB_PREFIX."invoice_type` ENGINE=InnoDB";
+    } else {
+        $patch['313']['patch'] = "SELECT 1";
+    }
+    $patch['313']['date']  = "20260408";
+
+    $patch['314']['name']  = "Migrate si_index to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['314']['patch'] = "ALTER TABLE `".TB_PREFIX."index` ENGINE=InnoDB";
+    } else {
+        $patch['314']['patch'] = "SELECT 1";
+    }
+    $patch['314']['date']  = "20260408";
+
+    $patch['315']['name']  = "Migrate si_products_attribute_type to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['315']['patch'] = "ALTER TABLE `".TB_PREFIX."products_attribute_type` ENGINE=InnoDB";
+    } else {
+        $patch['315']['patch'] = "SELECT 1";
+    }
+    $patch['315']['date']  = "20260408";
+
+    $patch['316']['name']  = "Migrate si_products_attributes to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['316']['patch'] = "ALTER TABLE `".TB_PREFIX."products_attributes` ENGINE=InnoDB";
+    } else {
+        $patch['316']['patch'] = "SELECT 1";
+    }
+    $patch['316']['date']  = "20260408";
+
+    $patch['317']['name']  = "Migrate si_products_values to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['317']['patch'] = "ALTER TABLE `".TB_PREFIX."products_values` ENGINE=InnoDB";
+    } else {
+        $patch['317']['patch'] = "SELECT 1";
+    }
+    $patch['317']['date']  = "20260408";
+
+    $patch['318']['name']  = "Migrate si_sql_patchmanager to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['318']['patch'] = "ALTER TABLE `".TB_PREFIX."sql_patchmanager` ENGINE=InnoDB";
+    } else {
+        $patch['318']['patch'] = "SELECT 1";
+    }
+    $patch['318']['date']  = "20260408";
+
+    $patch['319']['name']  = "Migrate si_user_domain to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['319']['patch'] = "ALTER TABLE `".TB_PREFIX."user_domain` ENGINE=InnoDB";
+    } else {
+        $patch['319']['patch'] = "SELECT 1";
+    }
+    $patch['319']['date']  = "20260408";
+
+    $patch['320']['name']  = "Migrate si_user_role to InnoDB";
+    if ($config->database->adapter === "pdo_mysql") {
+        $patch['320']['patch'] = "ALTER TABLE `".TB_PREFIX."user_role` ENGINE=InnoDB";
+    } else {
+        $patch['320']['patch'] = "SELECT 1";
+    }
+    $patch['320']['date']  = "20260408";
+

--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -1494,8 +1494,7 @@ function insertCustomer() {
     global $config;
 	$domain_id = domain_id::get();
 
-	extract( $_POST );
-	$sql = "INSERT INTO 
+	$sql = "INSERT INTO
 			".TB_PREFIX."customers
 			(
 				domain_id, attention, name, department, street_address, street_address2,
@@ -1504,36 +1503,36 @@ function insertCustomer() {
 				custom_field1, custom_field2,
 				custom_field3, custom_field4, enabled
 			)
-			VALUES 
+			VALUES
 			(
 				:domain_id ,:attention, :name, :department, :street_address, :street_address2,
 				:city, :state, :zip_code, :country, :phone, :mobile_phone,
-				:fax, :email, :notes, 
+				:fax, :email, :notes,
 				:custom_field1, :custom_field2,
 				:custom_field3, :custom_field4, :enabled
 			)";
 
 	return dbQuery($sql,
-		':attention', $attention,
-		':name', $name,
-		':department', $department,
-		':street_address', $street_address,
-		':street_address2', $street_address2,
-		':city', $city,
-		':state', $state,
-		':zip_code', $zip_code,
-		':country', $country,
-		':phone', $phone,
-		':mobile_phone', $mobile_phone,
-		':fax', $fax,
-		':email', $email,
-		':notes', $notes,
-		':custom_field1', $custom_field1,
-		':custom_field2', $custom_field2,
-		':custom_field3', $custom_field3,
-		':custom_field4', $custom_field4,
-		':enabled', $enabled,
-		':domain_id',$domain_id
+		':attention',     $_POST['attention']      ?? '',
+		':name',          $_POST['name']           ?? '',
+		':department',    $_POST['department']     ?? '',
+		':street_address',  $_POST['street_address']  ?? '',
+		':street_address2', $_POST['street_address2'] ?? '',
+		':city',          $_POST['city']           ?? '',
+		':state',         $_POST['state']          ?? '',
+		':zip_code',      $_POST['zip_code']       ?? '',
+		':country',       $_POST['country']        ?? '',
+		':phone',         $_POST['phone']          ?? '',
+		':mobile_phone',  $_POST['mobile_phone']   ?? '',
+		':fax',           $_POST['fax']            ?? '',
+		':email',         $_POST['email']          ?? '',
+		':notes',         $_POST['notes']          ?? '',
+		':custom_field1', $_POST['custom_field1']  ?? '',
+		':custom_field2', $_POST['custom_field2']  ?? '',
+		':custom_field3', $_POST['custom_field3']  ?? '',
+		':custom_field4', $_POST['custom_field4']  ?? '',
+		':enabled',       $_POST['enabled']        ?? '',
+		':domain_id',     $domain_id
 		);
 
 }

--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -32,7 +32,7 @@ function db_connector() {
 	*/
 	$pdoAdapter = substr($config->database->adapter, 4);
 
-	if(!defined('PDO::MYSQL_ATTR_INIT_COMMAND') AND $pdoAdapter == "mysql" AND $config->database->adapter->utf8 == true)
+	if(!defined('PDO::MYSQL_ATTR_INIT_COMMAND') AND $pdoAdapter == "mysql" AND $config->database->utf8 == true)
 	{
         simpleInvoicesError("PDO::mysql_attr");
 	}
@@ -44,15 +44,29 @@ function db_connector() {
 		{
 
 		    case "pgsql":
+		    	$port = !empty($config->database->params->port) ? ';port='.$config->database->params->port : '';
 		    	$connlink = new PDO(
-					$pdoAdapter.':host='.$config->database->params->host.';	dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
+					'pgsql:host='.$config->database->params->host.$port.';dbname='.$config->database->params->dbname,
+					$config->database->params->username,
+					$config->database->params->password
 				);
+				$connlink->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		    	break;
 
 		    case "sqlite":
-		    	$connlink = new PDO(
-					$pdoAdapter.':host='.$config->database->params->host.';	dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
-				);
+		    	$dsn = $config->database->params->dbname;
+		    	if ($dsn !== ':memory:' && (strlen($dsn) === 0 || $dsn[0] !== '/')) {
+		    		$base = preg_replace('/\.sqlite$/', '', $dsn);
+		    		$dir  = realpath('.') . '/databases/sqlite';
+		    		if (!is_dir($dir)) {
+		    			mkdir($dir, 0755, true);
+		    		}
+		    		$dsn = $dir . '/' . $base . '.sqlite';
+		    	}
+		    	$connlink = new PDO('sqlite:' . $dsn);
+				$connlink->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+				$connlink->exec('PRAGMA journal_mode=WAL');
+				$connlink->exec('PRAGMA foreign_keys=ON');
 				break;
 
 		    case "mysql":
@@ -61,14 +75,15 @@ function db_connector() {
                     case true:
 
         			   	$connlink = new PDO(
-        					'mysql:host='.$config->database->params->host.'; port='.$config->database->params->port.'; dbname='.$config->database->params->dbname, $config->database->params->username, $config->database->params->password,  array( PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8;")
+        					'mysql:host='.$config->database->params->host.';port='.$config->database->params->port.';dbname='.$config->database->params->dbname, $config->database->params->username, $config->database->params->password,  array( PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8;")
         				);
+        				$connlink->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		        		break;
 
         		    case false:
 		            default:
         		    	$connlink = new PDO(
-        					$pdoAdapter.':host='.$config->database->params->host.'; port='.$config->database->params->port.'; dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
+        					'mysql:host='.$config->database->params->host.';port='.$config->database->params->port.';dbname='.$config->database->params->dbname,	$config->database->params->username, $config->database->params->password
 		        		);
     				break;
                 }
@@ -191,14 +206,17 @@ function lastInsertId() {
 	$pdoAdapter = substr($config->database->adapter, 4);
 
 	if ($pdoAdapter == 'pgsql') {
-		$sql = 'SELECT lastval()';
-	} elseif ($pdoAdapter == 'mysql') {
-		$sql = 'SELECT last_insert_id()';
+		$sth = $dbh->prepare('SELECT lastval()');
+		$sth->execute();
+		return $sth->fetchColumn();
+	} elseif ($pdoAdapter == 'sqlite') {
+		return $dbh->lastInsertId();
+	} else {
+		// MySQL
+		$sth = $dbh->prepare('SELECT last_insert_id()');
+		$sth->execute();
+		return $sth->fetchColumn();
 	}
-	//echo $sql;
-	$sth = $dbh->prepare($sql);
-	$sth->execute();
-	return $sth->fetchColumn();
 }
 
 /*
@@ -269,7 +287,7 @@ function getGenericRecord($table, $id, $domain_id='', $id_field='id') {
 
 	$domain_id = domain_id::get($domain_id);
 
-	$record_sql = "SELECT * FROM `".TB_PREFIX."$table` WHERE `$id_field` = :id and `domain_id` = :domain_id";
+	$record_sql = "SELECT * FROM ".TB_PREFIX."$table WHERE $id_field = :id AND domain_id = :domain_id";
 	$sth = dbQuery($record_sql, ':id', $id, ':domain_id',$domain_id);
 	return $sth->fetch();
 }
@@ -1238,33 +1256,35 @@ function getSystemDefaults($domain_id='') {
 
 function updateDefault($name,$value,$extension_name="core") {
 
+	global $db_server;
 	$domain_id = domain_id::get();
 
 	$extension_id = getExtensionID($extension_name);
 	if (!($extension_id >= 0))
 	{
-		die(htmlsafe("Invalid extension name: ".$extension_name)); 
+		die(htmlsafe("Invalid extension name: ".$extension_name));
 	}
 
-	$sql = "INSERT INTO 
-		`".TB_PREFIX."system_defaults`
-		(
-			`name`, `value`, domain_id, extension_id
-		)
-		VALUES 
-		(
-			:name, :value, :domain_id, :extension_id
-		) 
-		ON DUPLICATE KEY UPDATE
-			`value` =  :value";
+	if ($db_server == 'mysql') {
+		$sql = "INSERT INTO `".TB_PREFIX."system_defaults`
+			(`name`, `value`, domain_id, extension_id)
+			VALUES (:name, :value, :domain_id, :extension_id)
+			ON DUPLICATE KEY UPDATE `value` = :value";
+	} else {
+		// PostgreSQL 9.5+ / SQLite 3.24+ upsert syntax
+		$sql = "INSERT INTO ".TB_PREFIX."system_defaults
+			(name, value, domain_id, extension_id)
+			VALUES (:name, :value, :domain_id, :extension_id)
+			ON CONFLICT (domain_id, name) DO UPDATE SET value = EXCLUDED.value";
+	}
 
-	if (dbQuery($sql, 
-		':value', $value, 
-		':domain_id', $domain_id, 
-		':name', $name, 
+	if (dbQuery($sql,
+		':value', $value,
+		':domain_id', $domain_id,
+		':name', $name,
 		':extension_id', $extension_id
 		)
-	) return true; 
+	) return true;
 	return false;
 }
 
@@ -1279,65 +1299,39 @@ function insertBiller() {
 	global $db_server;
 	$domain_id = domain_id::get();
 
-	if ($db_server == 'pgsql') {
-		$sql = "INSERT into
-			".TB_PREFIX."biller (
+	// pgsql/sqlite: omit id column (auto-generated); mysql: explicit NULL triggers AUTO_INCREMENT
+	if ($db_server == 'pgsql' || $db_server == 'sqlite') {
+		$sql = "INSERT INTO ".TB_PREFIX."biller (
 				domain_id, name, street_address, street_address2, city,
 				state, zip_code, country, phone, mobile_phone,
-				fax, email, logo, footer, notes, custom_field1,
-				custom_field2, custom_field3, custom_field4,
-				enabled
-			)
-		VALUES
-			(
+				fax, email, logo, footer, paypal_business_name,
+				paypal_notify_url, paypal_return_url, eway_customer_id,
+				paymentsgateway_api_id, notes, custom_field1,
+				custom_field2, custom_field3, custom_field4, enabled
+			) VALUES (
 				:domain_id, :name, :street_address, :street_address2, :city,
-				:state, :zip_code, :country, :phone,
-				:mobile_phone, :fax, :email, :logo, :footer,
-				:notes, :custom_field1, :custom_field2,
-				:custom_field3, :custom_field4, :enabled
-			 )";
+				:state, :zip_code, :country, :phone, :mobile_phone,
+				:fax, :email, :logo, :footer, :paypal_business_name,
+				:paypal_notify_url, :paypal_return_url, :eway_customer_id,
+				:paymentsgateway_api_id, :notes, :custom_field1,
+				:custom_field2, :custom_field3, :custom_field4, :enabled
+			)";
 	} else {
-		$sql = "INSERT into
-			".TB_PREFIX."biller
-			(
+		$sql = "INSERT INTO ".TB_PREFIX."biller (
 				id, domain_id, name, street_address, street_address2, city,
 				state, zip_code, country, phone, mobile_phone,
-				fax, email, logo, footer, paypal_business_name, 
-				paypal_notify_url, paypal_return_url, eway_customer_id, 
-                paymentsgateway_api_id, notes, custom_field1,
-				custom_field2, custom_field3, custom_field4,
-				enabled
-
-			)
-		VALUES
-			(
-				NULL,
-				:domain_id,
-				:name,
-				:street_address,
-				:street_address2,
-				:city,
-				:state,
-				:zip_code,
-				:country,
-				:phone,
-				:mobile_phone,
-				:fax,
-				:email,
-				:logo,
-				:footer,
-				:paypal_business_name,
-				:paypal_notify_url,
-				:paypal_return_url,
-				:eway_customer_id,
-				:paymentsgateway_api_id,
-				:notes,
-				:custom_field1,
-				:custom_field2,
-				:custom_field3,
-				:custom_field4,
-				:enabled
-			 )";
+				fax, email, logo, footer, paypal_business_name,
+				paypal_notify_url, paypal_return_url, eway_customer_id,
+				paymentsgateway_api_id, notes, custom_field1,
+				custom_field2, custom_field3, custom_field4, enabled
+			) VALUES (
+				NULL, :domain_id, :name, :street_address, :street_address2, :city,
+				:state, :zip_code, :country, :phone, :mobile_phone,
+				:fax, :email, :logo, :footer, :paypal_business_name,
+				:paypal_notify_url, :paypal_return_url, :eway_customer_id,
+				:paymentsgateway_api_id, :notes, :custom_field1,
+				:custom_field2, :custom_field3, :custom_field4, :enabled
+			)";
 	}
 
 	return dbQuery($sql,
@@ -1851,70 +1845,29 @@ function insertInvoice($type, $domain_id='') {
 		$type, $_POST['preference_id'])) {
 		return null;
 	}
-	$sql = "INSERT INTO
-		".TB_PREFIX."invoices (
-			id, 
-            index_id,
-			domain_id,
-			biller_id, 
-			customer_id, 
-			type_id,
-			preference_id, 
-			date, 
-			note,
-			custom_field1,
-			custom_field2,
-			custom_field3,
-			custom_field4
-		)
-		VALUES
-		(
-			NULL,
-			:index_id,
-			:domain_id,
-			:biller_id,
-			:customer_id,
-			:type,
-			:preference_id,
-			:date,
-			:note,
-			:customField1,
-			:customField2,
-			:customField3,
-			:customField4
-			)";
 
-	if ($db_server == 'pgsql') {
-		$sql = "INSERT INTO
-			".TB_PREFIX."invoices (
-				index_id,
-				domain_id,
-				biller_id, 
-				customer_id, 
-				type_id,
-				preference_id, 
-				date, 
-				note,
-				custom_field1,
-				custom_field2,
-				custom_field3,
-				custom_field4
-			)
-			VALUES
-			(
-				:index_id,
-				:domain_id,
-				:biller_id,
-				:customer_id,
-				:type,
-				:preference_id,
-				:date,
-				:note,
-				:customField1,
-				:customField2,
-				:customField3,
-				:customField4
-				)";
+	if ($db_server == 'pgsql' || $db_server == 'sqlite') {
+		// pgsql/sqlite: omit id column so the sequence/AUTOINCREMENT generates it
+		$sql = "INSERT INTO ".TB_PREFIX."invoices (
+				index_id, domain_id, biller_id, customer_id,
+				type_id, preference_id, date, note,
+				custom_field1, custom_field2, custom_field3, custom_field4
+			) VALUES (
+				:index_id, :domain_id, :biller_id, :customer_id,
+				:type, :preference_id, :date, :note,
+				:customField1, :customField2, :customField3, :customField4
+			)";
+	} else {
+		// MySQL: explicit NULL triggers AUTO_INCREMENT
+		$sql = "INSERT INTO ".TB_PREFIX."invoices (
+				id, index_id, domain_id, biller_id, customer_id,
+				type_id, preference_id, date, note,
+				custom_field1, custom_field2, custom_field3, custom_field4
+			) VALUES (
+				NULL, :index_id, :domain_id, :biller_id, :customer_id,
+				:type, :preference_id, :date, :note,
+				:customField1, :customField2, :customField3, :customField4
+			)";
 	}
 
     $pref_group=getPreference($_POST['preference_id']);
@@ -2526,35 +2479,31 @@ function maxInvoice($domain_id='') {
 //in this file are functions for all sql queries
 function checkTableExists($table = "" ) {
 
-	//$db = db::getInstance();
-	//var_dump($db);
-	$table == "" ? TB_PREFIX."biller" : $table;
+	if ($table == "") $table = TB_PREFIX."biller";
 
-  //  echo $table;
 	global $LANG;
 	global $dbh;
 	global $config;
-	switch ($config->database->adapter) 
+	switch ($config->database->adapter)
 	{
-
 		case "pdo_pgsql":
-			$sql = 'SELECT 1 FROM pg_tables WHERE tablename = '.$table.' LIMIT 1';
+			$sth = $dbh->prepare('SELECT 1 FROM pg_tables WHERE schemaname = current_schema() AND tablename = :table LIMIT 1');
+			$sth->execute(array(':table' => $table));
 			break;
 
 		case "pdo_sqlite":
-			$sql = 'SELECT * FROM '.$table.'LIMIT 1';
+			$sth = $dbh->prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table LIMIT 1");
+			$sth->execute(array(':table' => $table));
 			break;
+
 		case "pdo_mysql":
 		default:
-		//mysql
-			//$sql = "SELECT 1 FROM INFORMATION_SCHEMA.TABLES where table_name = :table LIMIT 1";
-			$sql = "SHOW TABLES LIKE '".$table."'";
+			$sth = $dbh->prepare("SHOW TABLES LIKE :table");
+			$sth->execute(array(':table' => $table));
 			break;
 	}
 
-	//$sth = $dbh->prepare($sql);
-	$sth = dbQuery($sql);
-	if ($sth->fetchAll())
+	if ($sth && $sth->fetch())
 	{
 		return true;
 	} else {
@@ -2569,10 +2518,13 @@ function checkFieldExists($table,$field) {
 	global $dbh;
 	global $db_server;
 
-	$sql = "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE column_name = :field AND table_name = :table LIMIT 1";
 	if ($db_server == 'pgsql') {
-		// Use a nicer syntax
-		$sql = "SELECT 1 FROM pg_attribute a INNER JOIN pg_class c ON (a.attrelid = c.oid)  WHERE c.relkind = 'r' AND c.relname = :table AND a.attname = :field AND NOT a.attisdropped AND a.attnum > 0 LIMIT 1";
+		$sql = "SELECT 1 FROM pg_attribute a INNER JOIN pg_class c ON (a.attrelid = c.oid) WHERE c.relkind = 'r' AND c.relname = :table AND a.attname = :field AND NOT a.attisdropped AND a.attnum > 0 LIMIT 1";
+	} elseif ($db_server == 'sqlite') {
+		// Use pragma_table_info() table-valued function (SQLite 3.16.0+)
+		$sql = "SELECT 1 FROM pragma_table_info(:table) WHERE name = :field LIMIT 1";
+	} else {
+		$sql = "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE column_name = :field AND table_name = :table LIMIT 1";
 	}
 
 	$sth = $dbh->prepare($sql);
@@ -2828,9 +2780,12 @@ function runPatches() {
 
 	$display_block = "";
 
-	$sql = "SHOW TABLES LIKE '".TB_PREFIX."sql_patchmanager'";
 	if ($db_server == 'pgsql') {
-		$sql = "SELECT 1 FROM pg_tables WHERE tablename ='".TB_PREFIX."sql_patchmanager'";
+		$sql = "SELECT 1 FROM pg_tables WHERE schemaname = current_schema() AND tablename ='".TB_PREFIX."sql_patchmanager'";
+	} elseif ($db_server == 'sqlite') {
+		$sql = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='".TB_PREFIX."sql_patchmanager'";
+	} else {
+		$sql = "SHOW TABLES LIKE '".TB_PREFIX."sql_patchmanager'";
 	}
 	$sth = dbQuery($sql);
 	$rows = $sth->fetchAll();
@@ -2981,19 +2936,48 @@ function run_sql_patch($id, $patch) {
 
 // ------------------------------------------------------------------------------
 function initialise_sql_patch() {
-	//SC: MySQL-only function, not porting to PostgreSQL
+	global $db_server;
 
-	#check sql patch 1
-	$sql_patch_init = "CREATE TABLE ".TB_PREFIX."sql_patchmanager (sql_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,sql_patch_ref VARCHAR( 50 ) NOT NULL ,sql_patch VARCHAR( 255 ) NOT NULL ,sql_release VARCHAR( 25 ) NOT NULL ,sql_statement TEXT NOT NULL) TYPE = MYISAM ";
+	// Build a portable CREATE TABLE for the patch manager
+	if ($db_server == 'pgsql') {
+		$sql_patch_init = "CREATE TABLE IF NOT EXISTS ".TB_PREFIX."sql_patchmanager (
+			sql_id SERIAL PRIMARY KEY,
+			sql_patch_ref VARCHAR(50) NOT NULL,
+			sql_patch VARCHAR(255) NOT NULL,
+			sql_release VARCHAR(25) NOT NULL,
+			sql_statement TEXT NOT NULL
+		)";
+	} elseif ($db_server == 'sqlite') {
+		$sql_patch_init = "CREATE TABLE IF NOT EXISTS ".TB_PREFIX."sql_patchmanager (
+			sql_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			sql_patch_ref VARCHAR(50) NOT NULL,
+			sql_patch VARCHAR(255) NOT NULL,
+			sql_release VARCHAR(25) NOT NULL,
+			sql_statement TEXT NOT NULL
+		)";
+	} else {
+		// MySQL
+		$sql_patch_init = "CREATE TABLE IF NOT EXISTS ".TB_PREFIX."sql_patchmanager (
+			sql_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			sql_patch_ref VARCHAR(50) NOT NULL,
+			sql_patch VARCHAR(255) NOT NULL,
+			sql_release VARCHAR(25) NOT NULL,
+			sql_statement TEXT NOT NULL
+		) ENGINE=MyISAM DEFAULT CHARSET=utf8";
+	}
 	dbQuery($sql_patch_init);
 
 	$log = "Step 2 - The SQL patch table has been created<br />";
 
-	echo $display_block;
-
-	$sql_insert = "INSERT INTO ".TB_PREFIX."sql_patchmanager
- ( sql_id  ,sql_patch_ref , sql_patch , sql_release , sql_statement )
-VALUES ('','1','Create ".TB_PREFIX."sql_patchmanger table','20060514', :patch)";
+	if ($db_server == 'mysql') {
+		$sql_insert = "INSERT INTO ".TB_PREFIX."sql_patchmanager
+			(sql_id, sql_patch_ref, sql_patch, sql_release, sql_statement)
+			VALUES (NULL, '1', 'Create ".TB_PREFIX."sql_patchmanager table', '20060514', :patch)";
+	} else {
+		$sql_insert = "INSERT INTO ".TB_PREFIX."sql_patchmanager
+			(sql_patch_ref, sql_patch, sql_release, sql_statement)
+			VALUES ('1', 'Create ".TB_PREFIX."sql_patchmanager table', '20060514', :patch)";
+	}
 	dbQuery($sql_insert, ':patch', $sql_patch_init);
 
 	$log .= "Step 3 - The SQL patch has been inserted into the SQL patch table<br />";

--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -2997,12 +2997,13 @@ function patch126() {
 		dbQuery($sql, ':description', $res['description'], ':total', $res['gross_total']);
 		$id = lastInsertId();
 
-		$sql = "UPDATE  ".TB_PREFIX."invoice_items SET product_id = :id, unit_price = :price WHERE ".TB_PREFIX."invoice_items.id = :item";
+		$sql = "UPDATE ".TB_PREFIX."invoice_items SET product_id = :id, unit_price = :price WHERE id = :item AND domain_id = :domain_id";
 
 		dbQuery($sql,
 			':id', $id[0],
 			':price', $res['gross_total'],
-			':item', $res['id']
+			':item', $res['id'],
+			':domain_id', $res['domain_id']
 			);
 	}
 }

--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -2963,7 +2963,7 @@ function initialise_sql_patch() {
 			sql_patch VARCHAR(255) NOT NULL,
 			sql_release VARCHAR(25) NOT NULL,
 			sql_statement TEXT NOT NULL
-		) ENGINE=MyISAM DEFAULT CHARSET=utf8";
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 	}
 	dbQuery($sql_patch_init);
 

--- a/modules/billers/save.php
+++ b/modules/billers/save.php
@@ -21,7 +21,7 @@ checkLogin();
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 #insert biller
 

--- a/modules/billers/xml.php
+++ b/modules/billers/xml.php
@@ -28,7 +28,7 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 	
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{

--- a/modules/billers/xml.php
+++ b/modules/billers/xml.php
@@ -42,8 +42,8 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 	}
 	
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/custom_fields/save.php
+++ b/modules/custom_fields/save.php
@@ -19,7 +19,7 @@
 checkLogin();
 
 # Deal with op and add some basic sanity checking
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 #edit custom field
 if (  $op === 'edit_custom_field' ) {

--- a/modules/customers/save.php
+++ b/modules/customers/save.php
@@ -21,7 +21,7 @@ checkLogin();
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 #insert customer
 

--- a/modules/customers/xml.php
+++ b/modules/customers/xml.php
@@ -46,8 +46,8 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 	}
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/customers/xml.php
+++ b/modules/customers/xml.php
@@ -81,7 +81,7 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 					LEFT JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
 					LEFT JOIN ".TB_PREFIX."invoice_items ii ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
 					LEFT JOIN (SELECT iv3.customer_id, p.domain_id, SUM(COALESCE(p.ac_amount, 0)) AS amount 
-							FROM ".TB_PREFIX."payment p INNER JOIN si_invoices iv3 
+							FROM ".TB_PREFIX."payment p INNER JOIN ".TB_PREFIX."invoices iv3
 						ON (iv3.id = p.ac_inv_id AND iv3.domain_id = p.domain_id)
 							GROUP BY iv3.customer_id, p.domain_id
 						) ap ON (ap.customer_id = c.id AND ap.domain_id = c.domain_id)

--- a/modules/customers/xml.php
+++ b/modules/customers/xml.php
@@ -32,7 +32,7 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{
@@ -72,9 +72,9 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 					, c.name as name 
 					, c.department as department
 					, (SELECT (CASE  WHEN c.enabled = 0 THEN '".$LANG['disabled']."' ELSE '".$LANG['enabled']."' END )) AS enabled
-					, SUM(COALESCE(IF(pr.status = 1, ii.total, 0),  0)) AS customer_total
+					, SUM(COALESCE(CASE WHEN pr.status = 1 THEN ii.total ELSE 0 END, 0)) AS customer_total
 					, COALESCE(ap.amount,0) AS paid
-					, (SUM(COALESCE(IF(pr.status = 1, ii.total, 0),  0)) - COALESCE(ap.amount,0)) AS owing
+					, (SUM(COALESCE(CASE WHEN pr.status = 1 THEN ii.total ELSE 0 END, 0)) - COALESCE(ap.amount,0)) AS owing
 			FROM
 					".TB_PREFIX."customers c
 					LEFT JOIN ".TB_PREFIX."invoices iv ON (c.id = iv.customer_id AND iv.domain_id = c.domain_id)
@@ -87,7 +87,7 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 						) ap ON (ap.customer_id = c.id AND ap.domain_id = c.domain_id)
 			WHERE c.domain_id = :domain_id
 					$where
-			GROUP BY CID
+			GROUP BY c.id, c.name, c.department
 			ORDER BY
 					$sort $dir
 				$limit";

--- a/modules/index/wizard.php
+++ b/modules/index/wizard.php
@@ -5,7 +5,7 @@
 
 checkLogin();
 
-$op          = !empty($_POST['op']) ? addslashes($_POST['op']) : null;
+$op          = $_POST['op'] ?? null;
 $json_path   = realpath(__DIR__ . '/../../databases/json/sample_data.json');
 $sample      = ($json_path && file_exists($json_path)) ? json_decode(file_get_contents($json_path), true) : [];
 

--- a/modules/invoices/invoice.php
+++ b/modules/invoices/invoice.php
@@ -56,11 +56,20 @@ for($i=1;$i<=4;$i++) {
 	$show_custom_field[$i] = show_custom_field("invoice_cf$i",'',"write",'',"details_screen",'','','');
 }
 
-$sql = "SELECT CONCAT(a.id, '-', v.id) as id
-			 , CONCAT(a.name, '-',v.value) AS display 
-		FROM ".TB_PREFIX."products_attributes a 
-			LEFT JOIN ".TB_PREFIX."products_values v 
-				ON (a.id = v.attribute_id);";
+global $db_server;
+if ($db_server === 'mysql') {
+    $sql = "SELECT CONCAT(a.id, '-', v.id) AS id
+                 , CONCAT(a.name, '-', v.value) AS display
+            FROM ".TB_PREFIX."products_attributes a
+                LEFT JOIN ".TB_PREFIX."products_values v
+                    ON (a.id = v.attribute_id)";
+} else {
+    $sql = "SELECT (CAST(a.id AS TEXT) || '-' || CAST(v.id AS TEXT)) AS id
+                 , (a.name || '-' || v.value) AS display
+            FROM ".TB_PREFIX."products_attributes a
+                LEFT JOIN ".TB_PREFIX."products_values v
+                    ON (a.id = v.attribute_id)";
+}
 $sth =  dbQuery($sql);
 $matrix = $sth->fetchAll();
 $smarty -> assign("matrix", $matrix);

--- a/modules/invoices/xml.php
+++ b/modules/invoices/xml.php
@@ -28,8 +28,8 @@ if($auth_session->role_name =='customer') {
 	$invoice->biller = $auth_session->user_id;
 }
 
-$invoice->query=isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-$invoice->qtype=isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+$invoice->query=$_REQUEST['query'] ?? null;
+$invoice->qtype=$_REQUEST['qtype'] ?? null;
 
 $large_dataset = getDefaultLargeDataset();
 if($large_dataset == $LANG['enabled'])

--- a/modules/payment_types/save.php
+++ b/modules/payment_types/save.php
@@ -7,7 +7,7 @@ checkLogin();
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 #insert payment type
 

--- a/modules/payment_types/save.php
+++ b/modules/payment_types/save.php
@@ -18,13 +18,13 @@ $sql = "INSERT INTO ".TB_PREFIX."tax VALUES ('$_POST['tax_description']','$_POST
 */
 
 	if ($db_server == 'pgsql') {
-		$sql = "INSERT into ".TB_PREFIX."payment_types
+		$sql = "INSERT INTO ".TB_PREFIX."payment_types
 				(domain_id, pt_description, pt_enabled)
 			VALUES
-				(:domain_id', :description, :enabled)";
+				(:domain_id, :description, :enabled)";
 	} else {
-		$sql = "INSERT into
-				".TB_PREFIX."payment_types
+		// MySQL and SQLite: NULL auto-fills the auto-increment id column
+		$sql = "INSERT INTO ".TB_PREFIX."payment_types
 			VALUES
 				(NULL, :domain_id, :description, :enabled)";
 	}

--- a/modules/payment_types/xml.php
+++ b/modules/payment_types/xml.php
@@ -40,8 +40,8 @@ function sql($type='', $dir, $sort, $rp, $page )
 	}
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/payment_types/xml.php
+++ b/modules/payment_types/xml.php
@@ -27,7 +27,7 @@ function sql($type='', $dir, $sort, $rp, $page )
 
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{

--- a/modules/payments/xml.php
+++ b/modules/payments/xml.php
@@ -10,6 +10,7 @@ $page = (isset($_REQUEST['page'])) ? $_REQUEST['page'] : "1" ;
 
 function sql($type='', $dir, $sort, $rp, $page )
 {
+	global \$db_server;
 	global $config;
 	global $auth_session;
 
@@ -28,7 +29,7 @@ function sql($type='', $dir, $sort, $rp, $page )
 
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{
@@ -58,14 +59,22 @@ function sql($type='', $dir, $sort, $rp, $page )
 		$sort = "ap.id";
 	}
 
-	$sql = "SELECT 
+	$index_name_expr = ($db_server === 'mysql')
+		? "(SELECT CONCAT(pr.pref_inv_wording,' ',iv.index_id))"
+		: "(pr.pref_inv_wording || ' ' || CAST(iv.index_id AS TEXT))";
+	$date_expr = ($db_server === 'sqlite')
+		? "strftime('%Y-%m-%d', ac_date)"
+		: ($db_server === 'pgsql'
+			? "TO_CHAR(ac_date, 'YYYY-MM-DD')"
+			: "DATE_FORMAT(ac_date,'%Y-%m-%d')");
+	$sql = "SELECT
 				ap.*
 				, c.name as cname
-				, (SELECT CONCAT(pr.pref_inv_wording,' ',iv.index_id)) as index_name
+				, $index_name_expr as index_name
 				, b.name as bname
 				, pt.pt_description AS description
 				, ac_notes AS notes
-				, DATE_FORMAT(ac_date,'%Y-%m-%d') AS date
+				, $date_expr AS date
 			FROM 
 				".TB_PREFIX."payment ap
 				INNER JOIN ".TB_PREFIX."invoices iv      ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)

--- a/modules/payments/xml.php
+++ b/modules/payments/xml.php
@@ -38,8 +38,8 @@ function sql($type='', $dir, $sort, $rp, $page )
 	/*SQL Limit - end*/
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/preferences/save.php
+++ b/modules/preferences/save.php
@@ -1,7 +1,7 @@
 <?php
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 
 $include_online_payment ='';

--- a/modules/preferences/xml.php
+++ b/modules/preferences/xml.php
@@ -40,8 +40,8 @@ function sql($type='', $dir, $sort, $rp, $page )
 	}
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/preferences/xml.php
+++ b/modules/preferences/xml.php
@@ -27,7 +27,7 @@ function sql($type='', $dir, $sort, $rp, $page )
 
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{

--- a/modules/product_attribute/save.php
+++ b/modules/product_attribute/save.php
@@ -5,7 +5,7 @@ checkLogin();
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 
 #insert invoice_preference

--- a/modules/product_attribute/xml.php
+++ b/modules/product_attribute/xml.php
@@ -23,8 +23,8 @@ if (!preg_match('/^(asc|desc)$/iD', $dir)) {
 }
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/product_value/save.php
+++ b/modules/product_value/save.php
@@ -5,7 +5,7 @@ checkLogin();
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 
 #insert invoice_preference

--- a/modules/product_value/xml.php
+++ b/modules/product_value/xml.php
@@ -23,8 +23,8 @@ if (!preg_match('/^(asc|desc)$/iD', $dir)) {
 }
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/products/save.php
+++ b/modules/products/save.php
@@ -5,7 +5,7 @@ checkLogin();
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 
 
 #insert product

--- a/modules/reports/report_debtors_aging_total.php
+++ b/modules/reports/report_debtors_aging_total.php
@@ -1,45 +1,13 @@
 <?php
-   if ($db_server == 'pgsql') {
-      // PostgreSQL: GROUP BY requires the full CASE expression (aliases not allowed in GROUP BY)
-      $aging_case = "(CASE WHEN (CURRENT_DATE - iv.date::date) <= 14 THEN '0-14'
-              WHEN (CURRENT_DATE - iv.date::date) <= 30 THEN '15-30'
-              WHEN (CURRENT_DATE - iv.date::date) <= 60 THEN '31-60'
-              WHEN (CURRENT_DATE - iv.date::date) <= 90 THEN '61-90'
-              ELSE '90+'
-         END)";
-      $sql = "SELECT
-        SUM(COALESCE(ii.total, 0)) AS inv_total
-      , COALESCE(ap.inv_paid, 0) AS inv_paid
-      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
-      , $aging_case AS aging
-FROM
-      ".TB_PREFIX."invoice_items ii
-      LEFT JOIN ".TB_PREFIX."invoices iv ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-      LEFT JOIN (
-  SELECT ap1.domain_id, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
-  FROM  ".TB_PREFIX."payment ap1
-      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
-  WHERE pr1.status = 1
-  GROUP BY ap1.domain_id
-  ) ap ON (ap.domain_id = iv.domain_id)
-WHERE
-          pr.status   = 1
-      AND ii.domain_id = :domain_id
-GROUP BY $aging_case;
-";
-   } elseif ($db_server == 'sqlite') {
-      $sql = "SELECT
+   // Single db-agnostic query: aging buckets are computed in PHP below.
+   // Verbose GROUP BY satisfies pgsql strict mode and works on MySQL/SQLite too.
+   // HAVING uses the full expression (alias references not allowed in pgsql HAVING).
+   // Payment subquery groups per invoice (correct for per-invoice owing calculation).
+   $sql = "SELECT
+        iv.date,
         SUM(COALESCE(ii.total, 0)) AS inv_total,
         COALESCE(ap.inv_paid, 0) AS inv_paid,
-        SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-        (CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 14 THEN '0-14'
-              WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '15-30'
-              WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
-              WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
-              ELSE '90+'
-        END) AS aging
+        SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
 FROM
         ".TB_PREFIX."invoice_items ii
         LEFT JOIN ".TB_PREFIX."invoices iv ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
@@ -56,54 +24,46 @@ WHERE
           pr.status = 1
       AND ii.domain_id = :domain_id
 GROUP BY
-      aging;
-      ";
-   } else {
-      $sql = "SELECT
-        SUM(COALESCE(ii.total, 0)) AS inv_total
-      , COALESCE(ap.inv_paid, 0) AS inv_paid
-      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
-      , (CASE WHEN DATEDIFF(NOW(),DATE) <= 14 THEN '0-14'
-              WHEN DATEDIFF(NOW(),DATE) <= 30 THEN '15-30'
-              WHEN DATEDIFF(NOW(),DATE) <= 60 THEN '31-60'
-              WHEN DATEDIFF(NOW(),DATE) <= 90 THEN '61-90'
-              ELSE '90+'
-          END) AS aging
-FROM
-      ".TB_PREFIX."invoice_items ii
-      LEFT JOIN ".TB_PREFIX."invoices iv ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-      LEFT JOIN (
-  SELECT ap1.domain_id, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
-  FROM  ".TB_PREFIX."payment ap1
-      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
-  WHERE pr1.status = 1
-  GROUP BY ap1.domain_id
-  ) ap ON (ap.domain_id = iv.domain_id)
-WHERE
-          pr.status   = 1
-      AND ii.domain_id = :domain_id
-GROUP BY
-	aging;
+      iv.id, iv.date, ap.inv_paid
+HAVING
+      SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) > 0
   ";
-  }
 
   $results = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 
   $sum_total = 0;
-  $sum_paid = 0;
+  $sum_paid  = 0;
   $sum_owing = 0;
-  $periods = array();
+  $periods   = array();
+  $today     = new DateTime();
 
-  while($period = $results->fetch()) {
-    $sum_total += $period['inv_total'];
-    $sum_paid += $period['inv_paid'];
-    $sum_owing += $period['inv_owing'];
-    array_push($periods, $period);
+  while($row = $results->fetch()) {
+    $age = (int)$today->diff(new DateTime($row['date']))->days;
+    if ($age <= 14)      $bucket = '0-14';
+    elseif ($age <= 30)  $bucket = '15-30';
+    elseif ($age <= 60)  $bucket = '31-60';
+    elseif ($age <= 90)  $bucket = '61-90';
+    else                 $bucket = '90+';
+
+    if (!isset($periods[$bucket])) {
+        $periods[$bucket] = array('aging' => $bucket, 'inv_total' => 0, 'inv_paid' => 0, 'inv_owing' => 0);
+    }
+    $periods[$bucket]['inv_total'] += $row['inv_total'];
+    $periods[$bucket]['inv_paid']  += $row['inv_paid'];
+    $periods[$bucket]['inv_owing'] += $row['inv_owing'];
+
+    $sum_total += $row['inv_total'];
+    $sum_paid  += $row['inv_paid'];
+    $sum_owing += $row['inv_owing'];
   }
 
-  $smarty -> assign('data', $periods);
+  // Sort buckets oldest-first so the template renders in consistent order.
+  $bucket_order = array('0-14' => 0, '15-30' => 1, '31-60' => 2, '61-90' => 3, '90+' => 4);
+  uksort($periods, function($a, $b) use ($bucket_order) {
+      return $bucket_order[$a] - $bucket_order[$b];
+  });
+
+  $smarty -> assign('data', array_values($periods));
   $smarty -> assign('sum_total', $sum_total);
   $smarty -> assign('sum_paid', $sum_paid);
   $smarty -> assign('sum_owing', $sum_owing);

--- a/modules/reports/report_debtors_aging_total.php
+++ b/modules/reports/report_debtors_aging_total.php
@@ -28,15 +28,44 @@ GROUP BY
 ORDER BY
 	aging DESC;
 ";
+   } elseif ($db_server == 'sqlite') {
+      $sql = "SELECT
+        SUM(COALESCE(ii.total, 0)) AS inv_total,
+        COALESCE(ap.inv_paid, 0) AS inv_paid,
+        SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
+        (CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 14 THEN '0-14'
+              WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '15-30'
+              WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
+              WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
+              ELSE '90+'
+        END) AS aging
+FROM
+        ".TB_PREFIX."invoice_items ii
+        LEFT JOIN ".TB_PREFIX."invoices iv ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."preferences pr ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+        LEFT JOIN (
+          SELECT ap1.ac_inv_id, ap1.domain_id, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
+          FROM ".TB_PREFIX."payment ap1
+              LEFT JOIN ".TB_PREFIX."invoices iv1 ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
+              LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
+          WHERE pr1.status = 1
+          GROUP BY ap1.ac_inv_id, ap1.domain_id
+        ) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+WHERE
+          pr.status = 1
+      AND ii.domain_id = :domain_id
+GROUP BY
+      aging;
+      ";
    } else {
       $sql = "SELECT
         SUM(COALESCE(ii.total, 0)) AS inv_total
       , COALESCE(ap.inv_paid, 0) AS inv_paid
       , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
-      , (CASE WHEN DATEDIFF(NOW(),DATE) <= '14 days' THEN '0-14'
-              WHEN DATEDIFF(NOW(),DATE) <= '30 days' THEN '15-30'
-              WHEN DATEDIFF(NOW(),DATE) <= '60 days' THEN '31-60'
-              WHEN DATEDIFF(NOW(),DATE) <= '90 days' THEN '61-90'
+      , (CASE WHEN DATEDIFF(NOW(),DATE) <= 14 THEN '0-14'
+              WHEN DATEDIFF(NOW(),DATE) <= 30 THEN '15-30'
+              WHEN DATEDIFF(NOW(),DATE) <= 60 THEN '31-60'
+              WHEN DATEDIFF(NOW(),DATE) <= 90 THEN '61-90'
               ELSE '90+'
           END) AS aging
 FROM
@@ -44,17 +73,17 @@ FROM
       LEFT JOIN ".TB_PREFIX."invoices iv ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
       LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
       LEFT JOIN (
-  SELECT ap1.domain_id, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid 
+  SELECT ap1.domain_id, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
   FROM  ".TB_PREFIX."payment ap1
       LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
       LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
-  WHERE pr1.status = 1 
+  WHERE pr1.status = 1
   GROUP BY ap1.domain_id
   ) ap ON (ap.domain_id = iv.domain_id)
 WHERE
           pr.status   = 1
       AND ii.domain_id = :domain_id
-GROUP BY 
+GROUP BY
 	aging;
   ";
   }

--- a/modules/reports/report_debtors_aging_total.php
+++ b/modules/reports/report_debtors_aging_total.php
@@ -1,32 +1,33 @@
 <?php
    if ($db_server == 'pgsql') {
+      // PostgreSQL: GROUP BY requires the full CASE expression (aliases not allowed in GROUP BY)
+      $aging_case = "(CASE WHEN (CURRENT_DATE - iv.date::date) <= 14 THEN '0-14'
+              WHEN (CURRENT_DATE - iv.date::date) <= 30 THEN '15-30'
+              WHEN (CURRENT_DATE - iv.date::date) <= 60 THEN '31-60'
+              WHEN (CURRENT_DATE - iv.date::date) <= 90 THEN '61-90'
+              ELSE '90+'
+         END)";
       $sql = "SELECT
-        sum(coalesce(ii.total, 0)) AS inv_total,
-        sum(coalesce(ap.ac_amount, 0)) AS inv_paid,
-
-        sum(coalesce(ii.total, 0)) -
-        sum(coalesce(ap.ac_amount, 0)) AS inv_owing,
-
-        (CASE   WHEN age(iv.date) <= '14 days'::interval THEN '0-14'
-                WHEN age(iv.date) <= '30 days'::interval THEN '15-30'
-                WHEN age(iv.date) <= '60 days'::interval THEN '31-60'
-                WHEN age(iv.date) <= '90 days'::interval THEN '61-90'
-                ELSE '90+'
-        END) AS aging
-
+        SUM(COALESCE(ii.total, 0)) AS inv_total
+      , COALESCE(ap.inv_paid, 0) AS inv_paid
+      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
+      , $aging_case AS aging
 FROM
-        ".TB_PREFIX."invoices iv LEFT JOIN
-        (SELECT i.invoice_id, i.domain_id, SUM(i.total) AS total
-         FROM ".TB_PREFIX."invoice_items i GROUP BY i.invoice_id, i.domain_id
-        ) ii ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id) LEFT JOIN
-        (SELECT p.ac_inv_id, p.domain_id, SUM(p.ac_amount) AS ac_amount
-        FROM ".TB_PREFIX."payment p GROUP BY p.ac_inv_id, p.domain_id
-        ) ap ON (iv.id = ap.ac_inv_id AND iv.domain_id = ap.domain_id)
-WHERE iv.domain_id = :domain_id
-GROUP BY
-        aging
-ORDER BY
-	aging DESC;
+      ".TB_PREFIX."invoice_items ii
+      LEFT JOIN ".TB_PREFIX."invoices iv ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+      LEFT JOIN ".TB_PREFIX."preferences pr ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+      LEFT JOIN (
+  SELECT ap1.domain_id, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
+  FROM  ".TB_PREFIX."payment ap1
+      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
+      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
+  WHERE pr1.status = 1
+  GROUP BY ap1.domain_id
+  ) ap ON (ap.domain_id = iv.domain_id)
+WHERE
+          pr.status   = 1
+      AND ii.domain_id = :domain_id
+GROUP BY $aging_case;
 ";
    } elseif ($db_server == 'sqlite') {
       $sql = "SELECT

--- a/modules/reports/report_debtors_by_aging.php
+++ b/modules/reports/report_debtors_by_aging.php
@@ -32,18 +32,57 @@
 	ORDER BY
         age DESC;
     ";
-       } else {
-	
-          $sql = "SELECT
-			iv.id, 
+   } elseif ($db_server == 'sqlite') {
+      $sql = "SELECT
+			iv.id,
 			iv.index_id,
 			pr.pref_inv_wording,
-			b.name AS biller, 
-			c.name AS customer, 
---			COUNT(ii.invoice_id) AS items,
+			b.name AS biller,
+			c.name AS customer,
 			SUM(COALESCE(ii.total, 0)) AS inv_total,
 			COALESCE(ap.inv_paid, 0) AS inv_paid,
---    inv_total - inv_paid AS inv_owing,
+			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
+
+			strftime('%Y-%m-%d', iv.date) AS date,
+			CAST(julianday('now') - julianday(iv.date) AS INTEGER) AS age,
+			(CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 14 THEN '0-14'
+				  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '15-30'
+				  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
+				  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
+				  ELSE '90+'
+			END) AS Aging
+
+		FROM
+            ".TB_PREFIX."invoices iv
+            LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+            LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id = b.id AND b.domain_id = iv.domain_id)
+            LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id = c.id AND c.domain_id = iv.domain_id)
+            LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+            LEFT JOIN (
+				SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+					FROM ".TB_PREFIX."payment
+					GROUP BY ac_inv_id, domain_id
+			) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+		WHERE
+				pr.status    = 1
+			AND iv.domain_id = :domain_id
+		GROUP BY
+			iv.id
+		HAVING
+			inv_owing > 0
+		ORDER BY
+			age DESC;
+		";
+   } else {
+      // MySQL
+      $sql = "SELECT
+			iv.id,
+			iv.index_id,
+			pr.pref_inv_wording,
+			b.name AS biller,
+			c.name AS customer,
+			SUM(COALESCE(ii.total, 0)) AS inv_total,
+			COALESCE(ap.inv_paid, 0) AS inv_paid,
 			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
 
 			DATE_FORMAT(`date`,'%Y-%m-%e') AS `date`,
@@ -56,27 +95,27 @@
 			END ) AS Aging
 
 		FROM
-            ".TB_PREFIX."invoices iv  
-            LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id    = iv.id      AND ii.domain_id = iv.domain_id)  
+            ".TB_PREFIX."invoices iv
+            LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id    = iv.id      AND ii.domain_id = iv.domain_id)
             LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id     = b.id       AND  b.domain_id = iv.domain_id)
             LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id   = c.id       AND  c.domain_id = iv.domain_id)
             LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
             LEFT JOIN (
-				SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid 
-					FROM ".TB_PREFIX."payment 
+				SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+					FROM ".TB_PREFIX."payment
 					GROUP BY ac_inv_id, domain_id
 			) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
-		WHERE   
+		WHERE
 				pr.status    = 1
 			AND iv.domain_id = :domain_id
-		GROUP BY 
+		GROUP BY
 			iv.id
-		HAVING 
+		HAVING
 			inv_owing > 0
-		ORDER BY 
+		ORDER BY
 			age DESC;
 		";
-    }
+   }
 
     $invoice_results = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 

--- a/modules/reports/report_debtors_by_aging.php
+++ b/modules/reports/report_debtors_by_aging.php
@@ -2,38 +2,6 @@
 
    if ($db_server == 'pgsql') {
       $sql = "SELECT
-        iv.id,
-        b.name AS biller,
-        c.name AS customer,
-
-        coalesce(ii.total, 0) AS inv_total,
-        coalesce(ap.total, 0) AS inv_paid,
-        coalesce(ii.total, 0) - coalesce(ap.total, 0) as inv_owing,
-
-        to_char(iv.date,'YYYY-MM-DD') as date,
-        age(iv.date) as age,
-        (CASE   WHEN age(iv.date) <= '14 days'::interval THEN '0-14'
-                WHEN age(iv.date) <= '30 days'::interval THEN '15-30'
-                WHEN age(iv.date) <= '60 days'::interval THEN '31-60'
-                WHEN age(iv.date) <= '90 days'::interval THEN '61-90'
-                ELSE '90+'
-        END) as aging
-
-	FROM
-        ".TB_PREFIX."invoices iv INNER JOIN
-	".TB_PREFIX."biller b ON (b.id = iv.biller_id) INNER JOIN
-	".TB_PREFIX."customers c ON (c.id = iv.customer_id) LEFT JOIN
-        (SELECT i.invoice_id, sum(i.total) AS total
-         FROM ".TB_PREFIX."invoice_items i GROUP BY i.invoice_id
-        ) ii ON (iv.id = ii.invoice_id) LEFT JOIN
-        (SELECT p.ac_inv_id, sum(p.ac_amount) AS total
-         FROM ".TB_PREFIX."payments p GROUP BY p.ac_inv_id
-        ) ap ON (iv.id = ap.ac_inv_id)
-	ORDER BY
-        age DESC;
-    ";
-   } elseif ($db_server == 'sqlite') {
-      $sql = "SELECT
 			iv.id,
 			iv.index_id,
 			pr.pref_inv_wording,
@@ -43,13 +11,13 @@
 			COALESCE(ap.inv_paid, 0) AS inv_paid,
 			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
 
-			strftime('%Y-%m-%d', iv.date) AS date,
-			CAST(julianday('now') - julianday(iv.date) AS INTEGER) AS age,
-			(CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 14 THEN '0-14'
-				  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '15-30'
-				  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
-				  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
-				  ELSE '90+'
+			TO_CHAR(iv.date, 'YYYY-MM-DD') AS date,
+			(CURRENT_DATE - iv.date::date) AS age,
+			(CASE WHEN (CURRENT_DATE - iv.date::date) <= 14 THEN '0-14'
+			      WHEN (CURRENT_DATE - iv.date::date) <= 30 THEN '15-30'
+			      WHEN (CURRENT_DATE - iv.date::date) <= 60 THEN '31-60'
+			      WHEN (CURRENT_DATE - iv.date::date) <= 90 THEN '61-90'
+			      ELSE '90+'
 			END) AS Aging
 
 		FROM
@@ -67,54 +35,95 @@
 				pr.status    = 1
 			AND iv.domain_id = :domain_id
 		GROUP BY
-			iv.id
+			iv.id, iv.index_id, iv.date, b.name, c.name, pr.pref_inv_wording, ap.inv_paid
 		HAVING
-			inv_owing > 0
+			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) > 0
 		ORDER BY
 			age DESC;
 		";
+   } elseif ($db_server == 'sqlite') {
+      $sql = "SELECT
+				iv.id,
+				iv.index_id,
+				pr.pref_inv_wording,
+				b.name AS biller,
+				c.name AS customer,
+				SUM(COALESCE(ii.total, 0)) AS inv_total,
+				COALESCE(ap.inv_paid, 0) AS inv_paid,
+				SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
+
+				strftime('%Y-%m-%d', iv.date) AS date,
+				CAST(julianday('now') - julianday(iv.date) AS INTEGER) AS age,
+				(CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 14 THEN '0-14'
+					  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '15-30'
+					  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
+					  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
+					  ELSE '90+'
+				END) AS Aging
+
+			FROM
+                ".TB_PREFIX."invoices iv
+                LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+                LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id = b.id AND b.domain_id = iv.domain_id)
+                LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id = c.id AND c.domain_id = iv.domain_id)
+                LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+                LEFT JOIN (
+					SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+						FROM ".TB_PREFIX."payment
+						GROUP BY ac_inv_id, domain_id
+				) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+			WHERE
+					pr.status    = 1
+				AND iv.domain_id = :domain_id
+			GROUP BY
+				iv.id
+			HAVING
+				inv_owing > 0
+			ORDER BY
+				age DESC;
+			";
    } else {
       // MySQL
       $sql = "SELECT
-			iv.id,
-			iv.index_id,
-			pr.pref_inv_wording,
-			b.name AS biller,
-			c.name AS customer,
-			SUM(COALESCE(ii.total, 0)) AS inv_total,
-			COALESCE(ap.inv_paid, 0) AS inv_paid,
-			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
+				iv.id,
+				iv.index_id,
+				pr.pref_inv_wording,
+				b.name AS biller,
+				c.name AS customer,
+				SUM(COALESCE(ii.total, 0)) AS inv_total,
+				COALESCE(ap.inv_paid, 0) AS inv_paid,
+				SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
 
-			DATE_FORMAT(`date`,'%Y-%m-%e') AS `date`,
-			(SELECT DATEDIFF(NOW(),`date`)) AS age,
-			(CASE WHEN DATEDIFF(NOW(),`date`) <= 14 THEN '0-14'
-				  WHEN DATEDIFF(NOW(),`date`) <= 30 THEN '15-30'
-				  WHEN DATEDIFF(NOW(),`date`) <= 60 THEN '31-60'
-				  WHEN DATEDIFF(NOW(),`date`) <= 90 THEN '61-90'
-				  ELSE '90+'
-			END ) AS Aging
+				DATE_FORMAT(`date`,'%Y-%m-%e') AS `date`,
+				(SELECT DATEDIFF(NOW(),`date`)) AS age,
+				(CASE WHEN DATEDIFF(NOW(),`date`) <= 14 THEN '0-14'
+					  WHEN DATEDIFF(NOW(),`date`) <= 30 THEN '15-30'
+					  WHEN DATEDIFF(NOW(),`date`) <= 60 THEN '31-60'
+					  WHEN DATEDIFF(NOW(),`date`) <= 90 THEN '61-90'
+					  ELSE '90+'
+				END ) AS Aging
 
-		FROM
-            ".TB_PREFIX."invoices iv
-            LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id    = iv.id      AND ii.domain_id = iv.domain_id)
-            LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id     = b.id       AND  b.domain_id = iv.domain_id)
-            LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id   = c.id       AND  c.domain_id = iv.domain_id)
-            LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-            LEFT JOIN (
-				SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
-					FROM ".TB_PREFIX."payment
-					GROUP BY ac_inv_id, domain_id
-			) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
-		WHERE
-				pr.status    = 1
-			AND iv.domain_id = :domain_id
-		GROUP BY
-			iv.id
-		HAVING
-			inv_owing > 0
-		ORDER BY
-			age DESC;
-		";
+			FROM
+                ".TB_PREFIX."invoices iv
+                LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id    = iv.id      AND ii.domain_id = iv.domain_id)
+                LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id     = b.id       AND  b.domain_id = iv.domain_id)
+                LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id   = c.id       AND  c.domain_id = iv.domain_id)
+                LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+                LEFT JOIN (
+					SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+						FROM ".TB_PREFIX."payment
+						GROUP BY ac_inv_id, domain_id
+				) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+			WHERE
+					pr.status    = 1
+				AND iv.domain_id = :domain_id
+			GROUP BY
+				iv.id
+			HAVING
+				inv_owing > 0
+			ORDER BY
+				age DESC;
+			";
    }
 
     $invoice_results = dbQuery($sql, ':domain_id', $auth_session->domain_id);

--- a/modules/reports/report_debtors_by_aging.php
+++ b/modules/reports/report_debtors_by_aging.php
@@ -1,7 +1,9 @@
 <?php
 
-   if ($db_server == 'pgsql') {
-      $sql = "SELECT
+   // Single db-agnostic query: age and aging bucket are computed in PHP below.
+   // Verbose GROUP BY satisfies pgsql strict mode and works on MySQL/SQLite too.
+   // HAVING uses the full expression (alias references not allowed in pgsql HAVING).
+   $sql = "SELECT
 			iv.id,
 			iv.index_id,
 			pr.pref_inv_wording,
@@ -10,15 +12,7 @@
 			SUM(COALESCE(ii.total, 0)) AS inv_total,
 			COALESCE(ap.inv_paid, 0) AS inv_paid,
 			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-
-			TO_CHAR(iv.date, 'YYYY-MM-DD') AS date,
-			(CURRENT_DATE - iv.date::date) AS age,
-			(CASE WHEN (CURRENT_DATE - iv.date::date) <= 14 THEN '0-14'
-			      WHEN (CURRENT_DATE - iv.date::date) <= 30 THEN '15-30'
-			      WHEN (CURRENT_DATE - iv.date::date) <= 60 THEN '31-60'
-			      WHEN (CURRENT_DATE - iv.date::date) <= 90 THEN '61-90'
-			      ELSE '90+'
-			END) AS Aging
+			iv.date
 
 		FROM
             ".TB_PREFIX."invoices iv
@@ -39,110 +33,32 @@
 		HAVING
 			SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) > 0
 		ORDER BY
-			age DESC;
-		";
-   } elseif ($db_server == 'sqlite') {
-      $sql = "SELECT
-				iv.id,
-				iv.index_id,
-				pr.pref_inv_wording,
-				b.name AS biller,
-				c.name AS customer,
-				SUM(COALESCE(ii.total, 0)) AS inv_total,
-				COALESCE(ap.inv_paid, 0) AS inv_paid,
-				SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-
-				strftime('%Y-%m-%d', iv.date) AS date,
-				CAST(julianday('now') - julianday(iv.date) AS INTEGER) AS age,
-				(CASE WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 14 THEN '0-14'
-					  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 30 THEN '15-30'
-					  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 60 THEN '31-60'
-					  WHEN CAST(julianday('now') - julianday(iv.date) AS INTEGER) <= 90 THEN '61-90'
-					  ELSE '90+'
-				END) AS Aging
-
-			FROM
-                ".TB_PREFIX."invoices iv
-                LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
-                LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id = b.id AND b.domain_id = iv.domain_id)
-                LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id = c.id AND c.domain_id = iv.domain_id)
-                LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-                LEFT JOIN (
-					SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
-						FROM ".TB_PREFIX."payment
-						GROUP BY ac_inv_id, domain_id
-				) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
-			WHERE
-					pr.status    = 1
-				AND iv.domain_id = :domain_id
-			GROUP BY
-				iv.id
-			HAVING
-				inv_owing > 0
-			ORDER BY
-				age DESC;
-			";
-   } else {
-      // MySQL
-      $sql = "SELECT
-				iv.id,
-				iv.index_id,
-				pr.pref_inv_wording,
-				b.name AS biller,
-				c.name AS customer,
-				SUM(COALESCE(ii.total, 0)) AS inv_total,
-				COALESCE(ap.inv_paid, 0) AS inv_paid,
-				SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-
-				DATE_FORMAT(`date`,'%Y-%m-%e') AS `date`,
-				(SELECT DATEDIFF(NOW(),`date`)) AS age,
-				(CASE WHEN DATEDIFF(NOW(),`date`) <= 14 THEN '0-14'
-					  WHEN DATEDIFF(NOW(),`date`) <= 30 THEN '15-30'
-					  WHEN DATEDIFF(NOW(),`date`) <= 60 THEN '31-60'
-					  WHEN DATEDIFF(NOW(),`date`) <= 90 THEN '61-90'
-					  ELSE '90+'
-				END ) AS Aging
-
-			FROM
-                ".TB_PREFIX."invoices iv
-                LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id    = iv.id      AND ii.domain_id = iv.domain_id)
-                LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id     = b.id       AND  b.domain_id = iv.domain_id)
-                LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id   = c.id       AND  c.domain_id = iv.domain_id)
-                LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-                LEFT JOIN (
-					SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
-						FROM ".TB_PREFIX."payment
-						GROUP BY ac_inv_id, domain_id
-				) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
-			WHERE
-					pr.status    = 1
-				AND iv.domain_id = :domain_id
-			GROUP BY
-				iv.id
-			HAVING
-				inv_owing > 0
-			ORDER BY
-				age DESC;
-			";
-   }
+			iv.date ASC";
 
     $invoice_results = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 
     $total_owed = 0;
     $periods = array();
+    $today = new DateTime();
 
     while($invoice = $invoice_results->fetch()) {
-      $periods[$invoice['Aging']]['name'] = $invoice['Aging'];
+        $age = (int)$today->diff(new DateTime($invoice['date']))->days;
+        if ($age <= 14)      $bucket = '0-14';
+        elseif ($age <= 30)  $bucket = '15-30';
+        elseif ($age <= 60)  $bucket = '31-60';
+        elseif ($age <= 90)  $bucket = '61-90';
+        else                 $bucket = '90+';
 
-      if (!array_key_exists('invoices', $periods[$invoice['Aging']])) {
-         $periods[$invoice['Aging']]['invoices'] = array();
-      }
+        $invoice['age']   = $age;
+        $invoice['Aging'] = $bucket;
 
-      array_push($periods[$invoice['Aging']]['invoices'], $invoice);
-
-      $periods[$invoice['Aging']]['sum_total'] += $invoice['inv_owing'];
-
-      $total_owed += $invoice['inv_owing'];
+        $periods[$bucket]['name'] = $bucket;
+        if (!array_key_exists('invoices', $periods[$bucket])) {
+            $periods[$bucket]['invoices'] = array();
+        }
+        array_push($periods[$bucket]['invoices'], $invoice);
+        $periods[$bucket]['sum_total'] += $invoice['inv_owing'];
+        $total_owed += $invoice['inv_owing'];
     }
 
     $smarty -> assign('data', $periods);

--- a/modules/reports/report_debtors_by_amount.php
+++ b/modules/reports/report_debtors_by_amount.php
@@ -12,38 +12,68 @@
         coalesce(ii.total, 0) - coalesce(ap.total, 0) AS inv_owing,
         iv.date
 FROM
-    ".TB_PREFIX."invoices iv 
+    ".TB_PREFIX."invoices iv
 	INNER JOIN ".TB_PREFIX."customers c ON (c.id = iv.customer_id)
 	INNER JOIN ".TB_PREFIX."biller b ON (b.id = iv.biller_id)
     LEFT JOIN (SELECT i.invoice_id, sum(i.total) AS total
          FROM ".TB_PREFIX."invoice_items i GROUP BY i.invoice_id
-        ) ii ON (iv.id = ii.invoice_id) 
+        ) ii ON (iv.id = ii.invoice_id)
     LEFT JOIN (SELECT p.ac_inv_id, sum(p.ac_amount) AS total
          FROM ".TB_PREFIX."payment p GROUP BY p.ac_inv_id
         ) ap ON (iv.id = ap.ac_inv_id)
 ORDER BY
         inv_owing DESC;
 ";
-   } else {
+   } elseif ($db_server == 'sqlite') {
       $sql = "SELECT
-      iv.id, 
+      iv.id,
       iv.index_id,
-	  pr.pref_inv_wording,
-      b.name AS biller, 
-      c.name AS customer, 
+      pr.pref_inv_wording,
+      b.name AS biller,
+      c.name AS customer,
       SUM(COALESCE(ii.total, 0)) AS inv_total,
       COALESCE(ap.inv_paid, 0) AS inv_paid,
       SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-      `date`
+      iv.date
 	FROM
-        ".TB_PREFIX."invoices iv  
-        LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id         AND ii.domain_id = iv.domain_id)  
-        LEFT JOIN ".TB_PREFIX."preferences pr   ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)  
+        ".TB_PREFIX."invoices iv
+        LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id         AND ii.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."preferences pr   ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id = b.id           AND  b.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id = c.id         AND  c.domain_id = iv.domain_id)
+        LEFT JOIN (
+	    SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+			FROM ".TB_PREFIX."payment
+			GROUP BY ac_inv_id, domain_id
+	) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+	WHERE
+		    pr.status = 1
+		AND iv.domain_id = :domain_id
+	GROUP BY
+		iv.id
+	ORDER BY
+        inv_owing DESC;
+";
+   } else {
+      $sql = "SELECT
+      iv.id,
+      iv.index_id,
+	  pr.pref_inv_wording,
+      b.name AS biller,
+      c.name AS customer,
+      SUM(COALESCE(ii.total, 0)) AS inv_total,
+      COALESCE(ap.inv_paid, 0) AS inv_paid,
+      SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
+      iv.date
+	FROM
+        ".TB_PREFIX."invoices iv
+        LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id         AND ii.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."preferences pr   ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
         LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id =  b.id          AND  b.domain_id = iv.domain_id)
         LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id =  c.id        AND  c.domain_id = iv.domain_id)
         LEFT JOIN (
-	    SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid 
-			FROM ".TB_PREFIX."payment 
+	    SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+			FROM ".TB_PREFIX."payment
 			GROUP BY ac_inv_id, domain_id
 	) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
 	WHERE
@@ -67,7 +97,7 @@ ORDER BY
   }
 
   $smarty -> assign('data', $invoices);
-  $smarty -> assign('total_owed', $total_owed);   
+  $smarty -> assign('total_owed', $total_owed);
 
   $smarty -> assign('pageActive', 'report');
   $smarty -> assign('active_tab', '#home');

--- a/modules/reports/report_debtors_by_amount.php
+++ b/modules/reports/report_debtors_by_amount.php
@@ -2,26 +2,32 @@
 
    if ($db_server == 'pgsql') {
       $sql = "SELECT
-        iv.id,
-        iv.index_id AS index_id,
-        b.name AS biller,
-        c.name AS customer,
-
-        coalesce(ii.total, 0) AS inv_total,
-        coalesce(ap.total, 0) AS inv_paid,
-        coalesce(ii.total, 0) - coalesce(ap.total, 0) AS inv_owing,
-        iv.date
-FROM
-    ".TB_PREFIX."invoices iv
-	INNER JOIN ".TB_PREFIX."customers c ON (c.id = iv.customer_id)
-	INNER JOIN ".TB_PREFIX."biller b ON (b.id = iv.biller_id)
-    LEFT JOIN (SELECT i.invoice_id, sum(i.total) AS total
-         FROM ".TB_PREFIX."invoice_items i GROUP BY i.invoice_id
-        ) ii ON (iv.id = ii.invoice_id)
-    LEFT JOIN (SELECT p.ac_inv_id, sum(p.ac_amount) AS total
-         FROM ".TB_PREFIX."payment p GROUP BY p.ac_inv_id
-        ) ap ON (iv.id = ap.ac_inv_id)
-ORDER BY
+      iv.id,
+      iv.index_id,
+      pr.pref_inv_wording,
+      b.name AS biller,
+      c.name AS customer,
+      SUM(COALESCE(ii.total, 0)) AS inv_total,
+      COALESCE(ap.inv_paid, 0) AS inv_paid,
+      SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
+      iv.date
+	FROM
+        ".TB_PREFIX."invoices iv
+        LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id         AND ii.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."preferences pr   ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id = b.id           AND  b.domain_id = iv.domain_id)
+        LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id = c.id         AND  c.domain_id = iv.domain_id)
+        LEFT JOIN (
+	    SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
+			FROM ".TB_PREFIX."payment
+			GROUP BY ac_inv_id, domain_id
+	) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
+	WHERE
+		    pr.status = 1
+		AND iv.domain_id = :domain_id
+	GROUP BY
+		iv.id, iv.index_id, iv.date, b.name, c.name, pr.pref_inv_wording, ap.inv_paid
+	ORDER BY
         inv_owing DESC;
 ";
    } elseif ($db_server == 'sqlite') {

--- a/modules/reports/report_debtors_by_amount.php
+++ b/modules/reports/report_debtors_by_amount.php
@@ -1,7 +1,8 @@
 <?php
 
-   if ($db_server == 'pgsql') {
-      $sql = "SELECT
+   // Single db-agnostic query: verbose GROUP BY satisfies pgsql's strict mode
+   // and is equally valid on MySQL and SQLite.
+   $sql = "SELECT
       iv.id,
       iv.index_id,
       pr.pref_inv_wording,
@@ -28,69 +29,7 @@
 	GROUP BY
 		iv.id, iv.index_id, iv.date, b.name, c.name, pr.pref_inv_wording, ap.inv_paid
 	ORDER BY
-        inv_owing DESC;
-";
-   } elseif ($db_server == 'sqlite') {
-      $sql = "SELECT
-      iv.id,
-      iv.index_id,
-      pr.pref_inv_wording,
-      b.name AS biller,
-      c.name AS customer,
-      SUM(COALESCE(ii.total, 0)) AS inv_total,
-      COALESCE(ap.inv_paid, 0) AS inv_paid,
-      SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-      iv.date
-	FROM
-        ".TB_PREFIX."invoices iv
-        LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id         AND ii.domain_id = iv.domain_id)
-        LEFT JOIN ".TB_PREFIX."preferences pr   ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
-        LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id = b.id           AND  b.domain_id = iv.domain_id)
-        LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id = c.id         AND  c.domain_id = iv.domain_id)
-        LEFT JOIN (
-	    SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
-			FROM ".TB_PREFIX."payment
-			GROUP BY ac_inv_id, domain_id
-	) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
-	WHERE
-		    pr.status = 1
-		AND iv.domain_id = :domain_id
-	GROUP BY
-		iv.id
-	ORDER BY
-        inv_owing DESC;
-";
-   } else {
-      $sql = "SELECT
-      iv.id,
-      iv.index_id,
-	  pr.pref_inv_wording,
-      b.name AS biller,
-      c.name AS customer,
-      SUM(COALESCE(ii.total, 0)) AS inv_total,
-      COALESCE(ap.inv_paid, 0) AS inv_paid,
-      SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing,
-      iv.date
-	FROM
-        ".TB_PREFIX."invoices iv
-        LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id         AND ii.domain_id = iv.domain_id)
-        LEFT JOIN ".TB_PREFIX."preferences pr   ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
-        LEFT JOIN ".TB_PREFIX."biller b         ON (iv.biller_id =  b.id          AND  b.domain_id = iv.domain_id)
-        LEFT JOIN ".TB_PREFIX."customers c      ON (iv.customer_id =  c.id        AND  c.domain_id = iv.domain_id)
-        LEFT JOIN (
-	    SELECT ac_inv_id, domain_id, SUM(COALESCE(ac_amount, 0)) AS inv_paid
-			FROM ".TB_PREFIX."payment
-			GROUP BY ac_inv_id, domain_id
-	) ap ON (ap.ac_inv_id = iv.id AND ap.domain_id = iv.domain_id)
-	WHERE
-		    pr.status = 1
-		AND iv.domain_id = :domain_id
-	GROUP BY
-		iv.id
-	ORDER BY
-        inv_owing DESC;
-";
-   }
+        inv_owing DESC";
 
   $invoice_results = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 

--- a/modules/reports/report_debtors_owing_by_customer.php
+++ b/modules/reports/report_debtors_owing_by_customer.php
@@ -1,7 +1,8 @@
 <?php
 
-  if ($db_server == 'pgsql') {
-      $sql = "
+  // Single db-agnostic query: verbose GROUP BY satisfies pgsql's strict mode
+  // and is equally valid on MySQL and SQLite.
+  $sql = "
 SELECT
         c.id AS cid
       , c.name AS customer
@@ -33,69 +34,6 @@ GROUP BY
 ORDER BY
 	inv_owing DESC;
 ";
-  } elseif ($db_server == 'sqlite') {
-      $sql = "
-SELECT
-        c.id AS cid
-      , c.name AS customer
-      , SUM(COALESCE(ii.total, 0)) AS inv_total
-      , COALESCE(ap.inv_paid, 0) AS inv_paid
-      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
-FROM
-      ".TB_PREFIX."customers c
-      LEFT JOIN ".TB_PREFIX."invoices iv      ON (iv.customer_id = c.id AND iv.domain_id = c.domain_id)
-      LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-      LEFT JOIN (
-  SELECT
-	  iv1.customer_id
-	, ap1.domain_id
-	, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
-  FROM  ".TB_PREFIX."payment ap1
-      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
-  WHERE
-      pr1.status = 1
-  GROUP BY iv1.customer_id, ap1.domain_id
-      ) ap ON (ap.customer_id = c.id AND ap.domain_id = c.domain_id)
-WHERE
-          pr.status   = 1
-      AND c.domain_id = :domain_id
-GROUP BY
-	c.id, c.name;
-";
-  } else {
-      $sql = "
-SELECT
-        c.id AS cid
-      , c.name AS customer
-      , SUM(COALESCE(ii.total, 0)) AS inv_total
-      , COALESCE(ap.inv_paid, 0) AS inv_paid
-      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
-FROM
-      ".TB_PREFIX."customers c
-      LEFT JOIN ".TB_PREFIX."invoices iv      ON (iv.customer_id = c.id AND iv.domain_id = c.domain_id)
-      LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
-      LEFT JOIN (
-  SELECT
-	  iv1.customer_id
-	, ap1.domain_id
-	, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
-  FROM  ".TB_PREFIX."payment ap1
-      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
-      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
-  WHERE
-      pr1.status = 1
-  GROUP BY iv1.customer_id, ap1.domain_id
-      ) ap ON (ap.customer_id = c.id AND ap.domain_id = c.domain_id)
-WHERE
-          pr.status   = 1
-      AND c.domain_id = :domain_id
-GROUP BY
-	c.id;
-";
-  }
 
   $customer_results = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 

--- a/modules/reports/report_debtors_owing_by_customer.php
+++ b/modules/reports/report_debtors_owing_by_customer.php
@@ -1,28 +1,38 @@
 <?php
 
   if ($db_server == 'pgsql') {
-      $sql = "SELECT
-        c.id AS cid,
-        c.name AS customer,
-        sum(coalesce(ii.total, 0)) AS inv_total,
-        sum(coalesce(ap.ac_amount, 0)) AS inv_paid,
-        sum(coalesce(ii.total, 0)) -
-        sum(coalesce(ap.ac_amount, 0)) AS inv_owing
-
+      $sql = "
+SELECT
+        c.id AS cid
+      , c.name AS customer
+      , SUM(COALESCE(ii.total, 0)) AS inv_total
+      , COALESCE(ap.inv_paid, 0) AS inv_paid
+      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
 FROM
-        ".TB_PREFIX."customers c LEFT JOIN
-        ".TB_PREFIX."invoices iv ON (c.id = iv.customer_id) LEFT JOIN
-	(SELECT i.invoice_id, coalesce(sum(i.total), 0) AS total
-         FROM ".TB_PREFIX."invoice_items i GROUP BY i.invoice_id
-        ) ii ON (iv.id = ii.invoice_id) LEFT JOIN
-	(SELECT p.ac_inv_id, coalesce(sum(p.ac_amount), 0) AS ac_amount
-         FROM ".TB_PREFIX."payment p GROUP BY p.ac_inv_id
-        ) ap ON (iv.id = ap.ac_inv_id)
+      ".TB_PREFIX."customers c
+      LEFT JOIN ".TB_PREFIX."invoices iv      ON (iv.customer_id = c.id AND iv.domain_id = c.domain_id)
+      LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+      LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+      LEFT JOIN (
+  SELECT
+	  iv1.customer_id
+	, ap1.domain_id
+	, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
+  FROM  ".TB_PREFIX."payment ap1
+      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
+      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
+  WHERE
+      pr1.status = 1
+  GROUP BY iv1.customer_id, ap1.domain_id
+      ) ap ON (ap.customer_id = c.id AND ap.domain_id = c.domain_id)
+WHERE
+          pr.status   = 1
+      AND c.domain_id = :domain_id
 GROUP BY
-        c.id, c.name
+	c.id, c.name, ap.inv_paid
 ORDER BY
-        inv_owing DESC;
-   ";
+	inv_owing DESC;
+";
   } elseif ($db_server == 'sqlite') {
       $sql = "
 SELECT

--- a/modules/reports/report_debtors_owing_by_customer.php
+++ b/modules/reports/report_debtors_owing_by_customer.php
@@ -23,7 +23,7 @@ GROUP BY
 ORDER BY
         inv_owing DESC;
    ";
-  } else {
+  } elseif ($db_server == 'sqlite') {
       $sql = "
 SELECT
         c.id AS cid
@@ -32,15 +32,15 @@ SELECT
       , COALESCE(ap.inv_paid, 0) AS inv_paid
       , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
 FROM
-      ".TB_PREFIX."customers c 
+      ".TB_PREFIX."customers c
       LEFT JOIN ".TB_PREFIX."invoices iv      ON (iv.customer_id = c.id AND iv.domain_id = c.domain_id)
       LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
       LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
       LEFT JOIN (
-  SELECT 
+  SELECT
 	  iv1.customer_id
 	, ap1.domain_id
-	, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid 
+	, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
   FROM  ".TB_PREFIX."payment ap1
       LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
       LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
@@ -51,7 +51,38 @@ FROM
 WHERE
           pr.status   = 1
       AND c.domain_id = :domain_id
-GROUP BY 
+GROUP BY
+	c.id, c.name;
+";
+  } else {
+      $sql = "
+SELECT
+        c.id AS cid
+      , c.name AS customer
+      , SUM(COALESCE(ii.total, 0)) AS inv_total
+      , COALESCE(ap.inv_paid, 0) AS inv_paid
+      , SUM(COALESCE(ii.total, 0)) - COALESCE(ap.inv_paid, 0) AS inv_owing
+FROM
+      ".TB_PREFIX."customers c
+      LEFT JOIN ".TB_PREFIX."invoices iv      ON (iv.customer_id = c.id AND iv.domain_id = c.domain_id)
+      LEFT JOIN ".TB_PREFIX."invoice_items ii ON (ii.invoice_id = iv.id AND ii.domain_id = iv.domain_id)
+      LEFT JOIN ".TB_PREFIX."preferences pr   ON (iv.preference_id = pr.pref_id AND pr.domain_id = iv.domain_id)
+      LEFT JOIN (
+  SELECT
+	  iv1.customer_id
+	, ap1.domain_id
+	, SUM(COALESCE(ap1.ac_amount, 0)) AS inv_paid
+  FROM  ".TB_PREFIX."payment ap1
+      LEFT JOIN ".TB_PREFIX."invoices iv1   ON (ap1.ac_inv_id = iv1.id AND ap1.domain_id = iv1.domain_id)
+      LEFT JOIN ".TB_PREFIX."preferences pr1 ON (pr1.pref_id = iv1.preference_id AND pr1.domain_id = iv1.domain_id)
+  WHERE
+      pr1.status = 1
+  GROUP BY iv1.customer_id, ap1.domain_id
+      ) ap ON (ap.customer_id = c.id AND ap.domain_id = c.domain_id)
+WHERE
+          pr.status   = 1
+      AND c.domain_id = :domain_id
+GROUP BY
 	c.id;
 ";
   }
@@ -67,7 +98,7 @@ GROUP BY
   }
 
   $smarty -> assign('data', $customers);
-  $smarty -> assign('total_owed', $total_owed);   
+  $smarty -> assign('total_owed', $total_owed);
 
   $smarty -> assign('pageActive', 'report');
   $smarty -> assign('active_tab', '#home');

--- a/modules/reports/report_sales_total.php
+++ b/modules/reports/report_sales_total.php
@@ -1,55 +1,27 @@
 <?php
     global $db_server;
 
-    if ($db_server == 'pgsql') {
-        $sql = "SELECT
-                  pr.index_group AS grp
-                , STRING_AGG(DISTINCT pr.pref_description, ',') AS template
-                , COUNT(DISTINCT ii.invoice_id) AS count
-                , SUM(ii.total) AS sum_total
-        FROM
-            ".TB_PREFIX."invoice_items ii
-            INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
-            INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
-        WHERE
-               pr.status = '1'
-           AND ii.domain_id = :domain_id
-        GROUP BY
-            pr.index_group
-        ";
-    } elseif ($db_server == 'sqlite') {
-        $sql = "SELECT
-                  pr.index_group AS grp
-                , GROUP_CONCAT(DISTINCT pr.pref_description) AS template
-                , COUNT(DISTINCT ii.invoice_id) AS count
-                , SUM(ii.total) AS sum_total
-        FROM
-            ".TB_PREFIX."invoice_items ii
-            INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
-            INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
-        WHERE
-               pr.status = '1'
-           AND ii.domain_id = :domain_id
-        GROUP BY
-            pr.index_group
-        ";
-    } else {
-        $sql = "SELECT
-                  pr.index_group AS grp
-                , GROUP_CONCAT(DISTINCT pr.pref_description SEPARATOR ',') AS template
-                , COUNT(DISTINCT ii.invoice_id) AS count
-                , SUM(ii.total) AS sum_total
-        FROM
-            ".TB_PREFIX."invoice_items ii
-            INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
-            INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
-        WHERE
-               pr.status = '1'
-           AND ii.domain_id = :domain_id
-        GROUP BY
-            pr.index_group
-        ";
-    }
+    // pgsql uses STRING_AGG; MySQL and SQLite both use GROUP_CONCAT with ',' as
+    // the default separator, so no SEPARATOR clause is needed.
+    $agg = ($db_server == 'pgsql')
+        ? "STRING_AGG(DISTINCT pr.pref_description, ',')"
+        : "GROUP_CONCAT(DISTINCT pr.pref_description)";
+
+    $sql = "SELECT
+              pr.index_group AS grp
+            , $agg AS template
+            , COUNT(DISTINCT ii.invoice_id) AS count
+            , SUM(ii.total) AS sum_total
+    FROM
+        ".TB_PREFIX."invoice_items ii
+        INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
+        INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
+    WHERE
+           pr.status = '1'
+       AND ii.domain_id = :domain_id
+    GROUP BY
+        pr.index_group
+    ";
 
     $sth = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 

--- a/modules/reports/report_sales_total.php
+++ b/modules/reports/report_sales_total.php
@@ -1,19 +1,55 @@
-<?php 
-    $sql = "SELECT 
-			  pr.index_group AS `group` 
-			, GROUP_CONCAT(DISTINCT pr.pref_description SEPARATOR ',') AS template 
-			, COUNT(DISTINCT ii.invoice_id) AS `count`
-			, SUM(ii.total) AS sum_total
-    FROM 
-        ".TB_PREFIX."invoice_items ii
-		INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id) 
-        INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id) 
-    WHERE
-           pr.status = '1'
-       AND ii.domain_id = :domain_id
-	GROUP BY
-		pr.index_group
-    ";
+<?php
+    global $db_server;
+
+    if ($db_server == 'pgsql') {
+        $sql = "SELECT
+                  pr.index_group AS grp
+                , STRING_AGG(DISTINCT pr.pref_description, ',') AS template
+                , COUNT(DISTINCT ii.invoice_id) AS count
+                , SUM(ii.total) AS sum_total
+        FROM
+            ".TB_PREFIX."invoice_items ii
+            INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
+            INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
+        WHERE
+               pr.status = '1'
+           AND ii.domain_id = :domain_id
+        GROUP BY
+            pr.index_group
+        ";
+    } elseif ($db_server == 'sqlite') {
+        $sql = "SELECT
+                  pr.index_group AS grp
+                , GROUP_CONCAT(DISTINCT pr.pref_description) AS template
+                , COUNT(DISTINCT ii.invoice_id) AS count
+                , SUM(ii.total) AS sum_total
+        FROM
+            ".TB_PREFIX."invoice_items ii
+            INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
+            INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
+        WHERE
+               pr.status = '1'
+           AND ii.domain_id = :domain_id
+        GROUP BY
+            pr.index_group
+        ";
+    } else {
+        $sql = "SELECT
+                  pr.index_group AS grp
+                , GROUP_CONCAT(DISTINCT pr.pref_description SEPARATOR ',') AS template
+                , COUNT(DISTINCT ii.invoice_id) AS count
+                , SUM(ii.total) AS sum_total
+        FROM
+            ".TB_PREFIX."invoice_items ii
+            INNER JOIN ".TB_PREFIX."invoices iv ON (iv.id = ii.invoice_id AND iv.domain_id = ii.domain_id)
+            INNER JOIN ".TB_PREFIX."preferences pr ON (pr.pref_id = iv.preference_id AND pr.domain_id = iv.domain_id)
+        WHERE
+               pr.status = '1'
+           AND ii.domain_id = :domain_id
+        GROUP BY
+            pr.index_group
+        ";
+    }
 
     $sth = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 

--- a/modules/tax_rates/save.php
+++ b/modules/tax_rates/save.php
@@ -8,7 +8,7 @@ $refresh_total = "<meta http-equiv='refresh' content='2;url=index.php?module=tax
 
 # Deal with op and add some basic sanity checking
 
-$op = !empty( $_POST['op'] ) ? addslashes( $_POST['op'] ) : NULL;
+$op = $_POST['op'] ?? null;
 $op = isset($_POST['cancel']) ? "cancel" : $op;
 
 switch ($op) {

--- a/modules/tax_rates/xml.php
+++ b/modules/tax_rates/xml.php
@@ -40,8 +40,8 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 	}
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/tax_rates/xml.php
+++ b/modules/tax_rates/xml.php
@@ -27,7 +27,7 @@ function sql($type='', $start, $dir, $sort, $rp, $page )
 	}
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{

--- a/modules/user/xml.php
+++ b/modules/user/xml.php
@@ -40,8 +40,8 @@ function sql($type='', $dir, $sort, $rp, $page )
 	}
 
 	$where = "";
-	$query = isset($_REQUEST['query']) ? $_REQUEST['query'] : null;
-	$qtype = isset($_REQUEST['qtype']) ? $_REQUEST['qtype'] : null;
+	$query = $_REQUEST['query'] ?? null;
+	$qtype = $_REQUEST['qtype'] ?? null;
 	if ( ! (empty($qtype) || empty($query)) ) {
 		if ( in_array($qtype, $valid_search_fields) ) {
 			$where = " AND $qtype LIKE :query ";

--- a/modules/user/xml.php
+++ b/modules/user/xml.php
@@ -27,7 +27,7 @@ function sql($type='', $dir, $sort, $rp, $page )
 	
 	/*SQL Limit - start*/
 	$start = (($page-1) * $rp);
-	$limit = "LIMIT $start, $rp";
+	$limit = "LIMIT $rp OFFSET $start";
 
 	if($type =="count")
 	{


### PR DESCRIPTION
## Summary
This PR extends Simple Invoices to support PostgreSQL and SQLite databases in addition to MySQL/MariaDB. The changes include database-agnostic query refactoring, schema files for new databases, Docker Compose overrides for easy testing, and comprehensive fixes to ensure compatibility across all three database systems.

## Key Changes

### Database Support
- **PostgreSQL 9.5+**: Added full schema definition (`databases/pgsql/structure.sql`) with proper SERIAL types and composite primary keys
- **SQLite 3.24+**: Added full schema definition (`databases/sqlite/structure.sql`) with AUTOINCREMENT and pragma configuration
- **MySQL/MariaDB**: Migrated from MyISAM to InnoDB engine with proper AUTO_INCREMENT handling via secondary KEY indexes

### Connection & Configuration
- Fixed PDO connection strings for PostgreSQL (proper DSN format, optional port handling)
- Implemented SQLite database path resolution (relative to `databases/sqlite/`, with `:memory:` support)
- Added error mode configuration (`PDO::ATTR_ERRMODE`) and SQLite pragmas (WAL mode, foreign keys)
- Fixed configuration property access (`$config->database->utf8` instead of `$config->database->adapter->utf8`)

### Query Compatibility
- Replaced MySQL-specific `LIMIT offset, count` syntax with standard `LIMIT count OFFSET offset` across all modules
- Converted MySQL `CONCAT()` to database-agnostic string concatenation (CONCAT for MySQL, `||` for PostgreSQL/SQLite)
- Refactored `lastInsertId()` function to handle PostgreSQL (`lastval()`), SQLite (`.lastInsertId()`), and MySQL (`last_insert_id()`)
- Updated `ON DUPLICATE KEY UPDATE` to use `ON CONFLICT ... DO UPDATE` for PostgreSQL/SQLite upsert operations
- Made report queries database-agnostic by computing aging buckets in PHP instead of database-specific date functions
- Removed backticks from SQL identifiers (MySQL-specific) for cross-database compatibility

### Code Quality
- Replaced deprecated `isset()` ternary patterns with null coalescing operator (`??`)
- Improved SQL formatting and consistency across all query definitions
- Added verbose `GROUP BY` clauses to satisfy PostgreSQL's strict mode while remaining compatible with MySQL/SQLite
- Fixed SQL injection vulnerabilities by removing `addslashes()` usage

### Docker & Deployment
- Added `docker-compose.sqlite.yml` override for SQLite testing (no external database service required)
- Added `docker-compose.pgsql.yml` override for PostgreSQL testing
- Updated `.env` with clear documentation for selecting database adapters
- Updated `Dockerfile` to include PostgreSQL (`pdo_pgsql`) and SQLite (`pdo_sqlite`) PHP extensions
- Modified `docker-entrypoint.sh` to handle database initialization for all three adapters

### Database Patches
- Added patches 295-320 in `sql_patches.php` to migrate MySQL tables to InnoDB with proper AUTO_INCREMENT key handling
- Patches are no-ops for PostgreSQL/SQLite (execute `SELECT 1`)

## Notable Implementation Details
- Global `$db_server` variable tracks the active database adapter type for conditional query logic
- Composite primary keys `(domain_id, id)` are preserved across all databases for multi-tenancy support
- SQLite database files are automatically created in `databases/sqlite/` with proper directory structure
- All three database systems now use consistent error handling and exception modes
- Report queries use a single unified query with PHP-side computation instead of database-specific branching where possible

https://claude.ai/code/session_018Vszy59YphTAJacJjC4LPJ