### PR TITLE
Add multi-tenancy support to product attributes and values

### DIFF
--- a/databases/mysql/structure.sql
+++ b/databases/mysql/structure.sql
@@ -285,19 +285,23 @@ CREATE TABLE IF NOT EXISTS `si_products_attribute_type` (
 
 CREATE TABLE IF NOT EXISTS `si_products_attributes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `domain_id` int(11) NOT NULL DEFAULT '1',
   `name` varchar(255) NOT NULL,
   `type_id` varchar(255) NOT NULL,
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
   `visible` TINYINT(1) DEFAULT 1 NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `idx_pa_domain_id` (`domain_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_products_values` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `domain_id` int(11) NOT NULL DEFAULT '1',
   `attribute_id` int(11) NOT NULL,
   `value` varchar(255) NOT NULL,
   `enabled` TINYINT(1) DEFAULT 1 NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `idx_pv_domain_id` (`domain_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `si_sql_patchmanager` (

--- a/databases/pgsql/structure.sql
+++ b/databases/pgsql/structure.sql
@@ -262,21 +262,25 @@ CREATE TABLE IF NOT EXISTS si_products_attribute_type (
 );
 
 CREATE TABLE IF NOT EXISTS si_products_attributes (
-  id      SERIAL,
-  name    VARCHAR(255) NOT NULL,
-  type_id VARCHAR(255) NOT NULL,
-  enabled SMALLINT NOT NULL DEFAULT 1,
-  visible SMALLINT NOT NULL DEFAULT 1,
+  id        SERIAL,
+  domain_id INTEGER NOT NULL DEFAULT 1,
+  name      VARCHAR(255) NOT NULL,
+  type_id   VARCHAR(255) NOT NULL,
+  enabled   SMALLINT NOT NULL DEFAULT 1,
+  visible   SMALLINT NOT NULL DEFAULT 1,
   PRIMARY KEY (id)
 );
+CREATE INDEX IF NOT EXISTS idx_pa_domain_id ON si_products_attributes (domain_id);
 
 CREATE TABLE IF NOT EXISTS si_products_values (
   id           SERIAL,
+  domain_id    INTEGER NOT NULL DEFAULT 1,
   attribute_id INTEGER NOT NULL,
   value        VARCHAR(255) NOT NULL,
   enabled      SMALLINT NOT NULL DEFAULT 1,
   PRIMARY KEY (id)
 );
+CREATE INDEX IF NOT EXISTS idx_pv_domain_id ON si_products_values (domain_id);
 
 CREATE TABLE IF NOT EXISTS si_sql_patchmanager (
   sql_id        SERIAL,

--- a/databases/sqlite/structure.sql
+++ b/databases/sqlite/structure.sql
@@ -258,19 +258,23 @@ CREATE TABLE IF NOT EXISTS si_products_attribute_type (
 );
 
 CREATE TABLE IF NOT EXISTS si_products_attributes (
-  id      INTEGER PRIMARY KEY AUTOINCREMENT,
-  name    TEXT NOT NULL,
-  type_id TEXT NOT NULL,
-  enabled INTEGER NOT NULL DEFAULT 1,
-  visible INTEGER NOT NULL DEFAULT 1
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id INTEGER NOT NULL DEFAULT 1,
+  name      TEXT NOT NULL,
+  type_id   TEXT NOT NULL,
+  enabled   INTEGER NOT NULL DEFAULT 1,
+  visible   INTEGER NOT NULL DEFAULT 1
 );
+CREATE INDEX IF NOT EXISTS idx_pa_domain_id ON si_products_attributes (domain_id);
 
 CREATE TABLE IF NOT EXISTS si_products_values (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id    INTEGER NOT NULL DEFAULT 1,
   attribute_id INTEGER NOT NULL,
   value        TEXT NOT NULL,
   enabled      INTEGER NOT NULL DEFAULT 1
 );
+CREATE INDEX IF NOT EXISTS idx_pv_domain_id ON si_products_values (domain_id);
 
 CREATE TABLE IF NOT EXISTS si_sql_patchmanager (
   sql_id        INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/include/class/product/attributes.php
+++ b/include/class/product/attributes.php
@@ -4,13 +4,15 @@ class product_attributes
 {
     public function get($id)
     {
+        $domain_id = domain_id::get();
         $sql = "SELECT pa.*, pat.name AS type
                 FROM ".TB_PREFIX."products_attributes pa
                     LEFT JOIN ".TB_PREFIX."products_attribute_type pat
                         ON (pa.type_id = pat.id)
-                WHERE pa.id = :id";
+                WHERE pa.id = :id
+                AND pa.domain_id = :domain_id";
 
-		$sth =  dbQuery($sql,':id',$id);
+		$sth = dbQuery($sql, ':id', $id, ':domain_id', $domain_id);
         $attribute = $sth->fetch();
 
         return $attribute;
@@ -18,8 +20,9 @@ class product_attributes
 
     public function getName($id)
     {
-        $sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE id = :id";
-        $sth =  dbQuery($sql,':id',$id);
+        $domain_id = domain_id::get();
+        $sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE id = :id AND domain_id = :domain_id";
+        $sth = dbQuery($sql, ':id', $id, ':domain_id', $domain_id);
         $attribute = $sth->fetch();
         return $attribute['name'];
     }
@@ -32,13 +35,13 @@ class product_attributes
 
     public function getValue($attribute_id, $value_id)
     {
-       
         $type = product_attributes::getType($attribute_id);
 
         if($type == 'list')
         {
-            $sql = "SELECT value FROM ".TB_PREFIX."products_values WHERE id = :id";
-            $sth =  dbQuery($sql,':id',$value_id);
+            $domain_id = domain_id::get();
+            $sql = "SELECT value FROM ".TB_PREFIX."products_values WHERE id = :id AND domain_id = :domain_id";
+            $sth = dbQuery($sql, ':id', $value_id, ':domain_id', $domain_id);
             $attribute = $sth->fetch();
 
             return $attribute['value'];
@@ -50,8 +53,9 @@ class product_attributes
 
 	public function getVisible($id)
     {
-        $sql = "SELECT visible FROM ".TB_PREFIX."products_attributes WHERE id = :id";
-        $sth =  dbQuery($sql,':id',$id);
+        $domain_id = domain_id::get();
+        $sql = "SELECT visible FROM ".TB_PREFIX."products_attributes WHERE id = :id AND domain_id = :domain_id";
+        $sth = dbQuery($sql, ':id', $id, ':domain_id', $domain_id);
         $attribute = $sth->fetch();
         if($attribute['visible'] =='1')
         {
@@ -64,8 +68,9 @@ class product_attributes
 
 	public function getAll()
     {
-        $sql = "SELECT * FROM ".TB_PREFIX."products_attributes";
-        $sth =  dbQuery($sql);
+        $domain_id = domain_id::get();
+        $sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+        $sth = dbQuery($sql, ':domain_id', $domain_id);
         $attributes = $sth->fetchAll();
         return $attributes;
     }

--- a/include/sql_patches.php
+++ b/include/sql_patches.php
@@ -2086,3 +2086,37 @@ PRIMARY KEY ( `domain_id`, `id` )
     }
     $patch['329']['date']  = '20260413';
 
+    $patch['330']['name'] = "Add domain_id to products_attributes for multi-tenancy";
+    switch ($config->database->adapter) {
+        case 'pdo_pgsql':
+        case 'pdo_sqlite':
+            $patch['330']['patch'] = checkFieldExists(TB_PREFIX.'products_attributes', 'domain_id')
+                ? 'SELECT 1'
+                : "ALTER TABLE ".TB_PREFIX."products_attributes ADD COLUMN domain_id INT NOT NULL DEFAULT 1";
+            break;
+        case 'pdo_mysql':
+        default:
+            $patch['330']['patch'] = checkFieldExists(TB_PREFIX.'products_attributes', 'domain_id')
+                ? 'SELECT 1'
+                : "ALTER TABLE `".TB_PREFIX."products_attributes` ADD COLUMN `domain_id` INT(11) NOT NULL DEFAULT '1' AFTER `id`, ADD KEY `idx_pa_domain_id` (`domain_id`)";
+            break;
+    }
+    $patch['330']['date'] = "20260416";
+
+    $patch['331']['name'] = "Add domain_id to products_values for multi-tenancy";
+    switch ($config->database->adapter) {
+        case 'pdo_pgsql':
+        case 'pdo_sqlite':
+            $patch['331']['patch'] = checkFieldExists(TB_PREFIX.'products_values', 'domain_id')
+                ? 'SELECT 1'
+                : "ALTER TABLE ".TB_PREFIX."products_values ADD COLUMN domain_id INT NOT NULL DEFAULT 1";
+            break;
+        case 'pdo_mysql':
+        default:
+            $patch['331']['patch'] = checkFieldExists(TB_PREFIX.'products_values', 'domain_id')
+                ? 'SELECT 1'
+                : "ALTER TABLE `".TB_PREFIX."products_values` ADD COLUMN `domain_id` INT(11) NOT NULL DEFAULT '1' AFTER `id`, ADD KEY `idx_pv_domain_id` (`domain_id`)";
+            break;
+    }
+    $patch['331']['date'] = "20260416";
+

--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -706,9 +706,9 @@ function insertProduct($enabled=1,$visible=1, $domain_id='') {
 	$domain_id = domain_id::get($domain_id);
 
 	if (isset($_POST['enabled'])) $enabled = $_POST['enabled'];
-    //select all attribts
-    $sql = "SELECT * FROM ".TB_PREFIX."products_attributes";
-    $sth =  dbQuery($sql);
+    //select all attributes
+    $sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+    $sth = dbQuery($sql, ':domain_id', $domain_id);
     $attributes = $sth->fetchAll();
 
 	$logger->log('Attr: '.var_export($attributes,true), LegacyLogger::INFO);
@@ -797,8 +797,8 @@ function updateProduct($domain_id='') {
 	$domain_id = domain_id::get($domain_id);
 
     //select all attributes
-    $sql = "SELECT * FROM ".TB_PREFIX."products_attributes";
-    $sth =  dbQuery($sql);
+    $sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+    $sth = dbQuery($sql, ':domain_id', $domain_id);
     $attributes = $sth->fetchAll();
 
     $attr = array();

--- a/modules/api/ach.php
+++ b/modules/api/ach.php
@@ -11,13 +11,21 @@ if ($_POST['pg_response_code']=='A01') {
 	$logger->log('ACH Data:', LegacyLogger::INFO);
 	$logger->log($paypal_data, LegacyLogger::INFO);
 
+	// Resolve domain_id from the invoice referenced by this payment
+	$ach_invoice_id = (int)$_POST['pg_consumerorderid'];
+	$domain_row = dbQuery(
+		"SELECT domain_id FROM ".TB_PREFIX."invoices WHERE id = :id LIMIT 1",
+		':id', $ach_invoice_id
+	)->fetch();
+	$resolved_domain_id = $domain_row ? (string)$domain_row['domain_id'] : '1';
+
 	$check_payment = new payment();
 	$check_payment->filter='online_payment_id';
 	$check_payment->online_payment_id = $_POST['pg_consumerorderid'];
-	$check_payment->domain_id = '1';
+	$check_payment->domain_id = $resolved_domain_id;
     $number_of_payments = $check_payment->count();
 	$logger->log('ACH - number of times this payment is in the db: '.$number_of_payments, LegacyLogger::INFO);
-	
+
 	if($number_of_payments > 0)
 	{
 		$xml_message = 'Online payment for invoices: '.$_POST['pg_consumerorderid'].' has already been entered into Simple Invoices';
@@ -33,11 +41,11 @@ if ($_POST['pg_response_code']=='A01') {
 		$payment->ac_notes = $paypal_data;
 		$payment->ac_date = date( 'Y-m-d');
 		$payment->online_payment_id = $_POST['pg_consumerorderid'];
-		$payment->domain_id = '1';
+		$payment->domain_id = $resolved_domain_id;
 
 			$payment_type = new payment_type();
 			$payment_type->type = "ACH";
-			$payment_type->domain_id = '1';
+			$payment_type->domain_id = $resolved_domain_id;
 
 		$payment->ac_payment_type = $payment_type->select_or_insert_where();
 		$logger->log('ACH - payment_type='.$payment->ac_payment_type, LegacyLogger::INFO);

--- a/modules/invoices/details.php
+++ b/modules/invoices/details.php
@@ -37,6 +37,7 @@ for($i=1;$i<=4;$i++) {
     $customFields[$i] = show_custom_field("invoice_cf$i",$invoice["custom_field$i"],"write",'',"details_screen",'','','');
 }
 
+$current_domain_id = domain_id::get();
 foreach($invoiceItems as $key=>$value)
 {
     //get list of attributes
@@ -50,29 +51,31 @@ foreach($invoiceItems as $key=>$value)
             if($v == 'true')
             {
                 $attr_id = (int)$k; // Cast to integer to prevent SQL injection
-                $attr_name_sql = 'select 
-                    a.name as name, a.enabled as enabled,  t.name type 
-                    from 
-                        si_products_attributes as a, 
-                        si_products_attribute_type as t 
-                   where 
+                $attr_name_sql = 'SELECT
+                    a.name as name, a.enabled as enabled, t.name type
+                    FROM
+                        si_products_attributes as a,
+                        si_products_attribute_type as t
+                   WHERE
                         a.type_id = t.id
-                        AND a.id = :attr_id';
-                $attr_name = dbQuery($attr_name_sql, ':attr_id', $attr_id);
+                        AND a.id = :attr_id
+                        AND a.domain_id = :domain_id';
+                $attr_name = dbQuery($attr_name_sql, ':attr_id', $attr_id, ':domain_id', $current_domain_id);
                 $attr_name = $attr_name->fetch();
 
-                $sql2 = 'select 
-                        a.name as name, 
-                        v.id as id, 
-                        v.value as value, 
-                        v.enabled as enabled 
-                   from 
-                        si_products_attributes a, 
-                        si_products_values v 
-                   where 
-                        a.id = v.attribute_id 
-                        AND a.id = :attr_id';
-                $states2 = dbQuery($sql2, ':attr_id', $attr_id);
+                $sql2 = 'SELECT
+                        a.name as name,
+                        v.id as id,
+                        v.value as value,
+                        v.enabled as enabled
+                   FROM
+                        si_products_attributes a
+                            JOIN si_products_values v
+                                ON (v.attribute_id = a.id AND v.domain_id = a.domain_id)
+                   WHERE
+                        a.id = :attr_id
+                        AND a.domain_id = :domain_id';
+                $states2 = dbQuery($sql2, ':attr_id', $attr_id, ':domain_id', $current_domain_id);
 
                 if($attr_name['enabled'] =='1' AND $attr_name['type'] == 'list')
                 {

--- a/modules/invoices/invoice.php
+++ b/modules/invoices/invoice.php
@@ -57,20 +57,23 @@ for($i=1;$i<=4;$i++) {
 }
 
 global $db_server;
+$matrix_domain_id = domain_id::get();
 if ($db_server === 'mysql') {
     $sql = "SELECT CONCAT(a.id, '-', v.id) AS id
                  , CONCAT(a.name, '-', v.value) AS display
             FROM ".TB_PREFIX."products_attributes a
                 LEFT JOIN ".TB_PREFIX."products_values v
-                    ON (a.id = v.attribute_id)";
+                    ON (a.id = v.attribute_id AND a.domain_id = v.domain_id)
+            WHERE a.domain_id = :domain_id";
 } else {
     $sql = "SELECT (CAST(a.id AS TEXT) || '-' || CAST(v.id AS TEXT)) AS id
                  , (a.name || '-' || v.value) AS display
             FROM ".TB_PREFIX."products_attributes a
                 LEFT JOIN ".TB_PREFIX."products_values v
-                    ON (a.id = v.attribute_id)";
+                    ON (a.id = v.attribute_id AND a.domain_id = v.domain_id)
+            WHERE a.domain_id = :domain_id";
 }
-$sth =  dbQuery($sql);
+$sth = dbQuery($sql, ':domain_id', $matrix_domain_id);
 $matrix = $sth->fetchAll();
 $bladeView -> assign("matrix", $matrix);
 

--- a/modules/invoices/product_ajax.php
+++ b/modules/invoices/product_ajax.php
@@ -21,19 +21,23 @@ if(isset($_GET['id']) && is_numeric($_GET['id']) && $_GET['id'] > 0)
         {
             if($v == 'true')
             {
-                $attr_name_sql = sprintf('select
-                    a.name as name, a.enabled as enabled,  t.name type
-                    from
-                        si_products_attributes as a,
-                        si_products_attribute_type as t
-                   where
-                        a.type_id = t.id
-                        AND a.id = %d', $k);
-                $attr_name = dbQuery($attr_name_sql);
+                $attr_id = (int)$k;
+                $attr_name_sql = "SELECT a.name as name, a.enabled as enabled, t.name type
+                    FROM ".TB_PREFIX."products_attributes as a,
+                         ".TB_PREFIX."products_attribute_type as t
+                   WHERE a.type_id = t.id
+                     AND a.id = :attr_id
+                     AND a.domain_id = :domain_id";
+                $attr_name = dbQuery($attr_name_sql, ':attr_id', $attr_id, ':domain_id', $auth_session->domain_id);
                 $attr_name = $attr_name->fetch();
 
-                $sql2 = sprintf("select a.name as name, v.id as id, v.value as value, v.enabled as enabled from ".TB_PREFIX."products_attributes a, ".TB_PREFIX."products_values v where a.id = v.attribute_id AND a.id = %d", $k);
-                $states2 = dbQuery($sql2);
+                $sql2 = "SELECT a.name as name, v.id as id, v.value as value, v.enabled as enabled
+                         FROM ".TB_PREFIX."products_attributes a
+                             JOIN ".TB_PREFIX."products_values v
+                                 ON (v.attribute_id = a.id AND v.domain_id = a.domain_id)
+                         WHERE a.id = :attr_id
+                           AND a.domain_id = :domain_id";
+                $states2 = dbQuery($sql2, ':attr_id', $attr_id, ':domain_id', $auth_session->domain_id);
 
                 if($attr_name['enabled'] =='1' AND $attr_name['type'] == 'list')
                 {

--- a/modules/invoices/quick_view.php
+++ b/modules/invoices/quick_view.php
@@ -55,8 +55,8 @@ for($i=1;$i<=4;$i++) {
 }
 
 
-$sql = "SELECT * FROM ".TB_PREFIX."products_attributes";
-$sth =  dbQuery($sql);
+$sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+$sth = dbQuery($sql, ':domain_id', $auth_session->domain_id);
 $attributes = $sth->fetchAll();
 $bladeView -> assign("attributes", $attributes);
 //Customer accounts sections

--- a/modules/product_attribute/details.php
+++ b/modules/product_attribute/details.php
@@ -10,8 +10,9 @@ if ($_POST['name'] != "" ) {
 #get the invoice id
 $id = $_GET['id'];
 
-$sql_prod = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE id = :id;";
-$sth_prod =  dbQuery($sql_prod, ':id', $id);
+$domain_id = domain_id::get();
+$sql_prod = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE id = :id AND domain_id = :domain_id";
+$sth_prod = dbQuery($sql_prod, ':id', $id, ':domain_id', $domain_id);
 $product_attribute = $sth_prod->fetch();
 $type = product_attributes::get($id);
 $product_attribute['type'] = $type['type'];

--- a/modules/product_attribute/save.php
+++ b/modules/product_attribute/save.php
@@ -1,5 +1,5 @@
 <?php
-// -Gates 5/5/2008 added domain_id to parameters 
+// -Gates 5/5/2008 added domain_id to parameters
 //stop the direct browsing to this file - let index.php handle which files get displayed
 checkLogin();
 
@@ -11,11 +11,13 @@ $op = $_POST['op'] ?? null;
 #insert invoice_preference
 if (  $op === 'insert_product_attribute' ) {
 
+	$domain_id = domain_id::get();
 	$sql = "INSERT into
 		".TB_PREFIX."products_attributes
+		(domain_id, name, type_id, enabled, visible)
 	VALUES
 		(
-			NULL,
+			:domain_id,
 			:name,
 			:type_id,
 			:enabled,
@@ -23,6 +25,7 @@ if (  $op === 'insert_product_attribute' ) {
 		 )";
 
 	if (dbQuery($sql,
+	  ':domain_id', $domain_id,
 	  ':name', $_POST['name'],
 	  ':type_id', $_POST['type_id'],
 	  ':enabled', $_POST['enabled'],
@@ -45,6 +48,7 @@ if (  $op === 'insert_product_attribute' ) {
 else if (  $op === 'edit_product_attribute' ) {
 
 	if (isset($_POST['save_product_attribute'])) {
+		$domain_id = domain_id::get();
 		$sql = "UPDATE
 				".TB_PREFIX."products_attributes
 			SET
@@ -53,14 +57,16 @@ else if (  $op === 'edit_product_attribute' ) {
 				enabled = :enabled,
 				visible = :visible
 			WHERE
-				id = :id";
+				id = :id
+			AND domain_id = :domain_id";
 
 		if (dbQuery($sql,
 		  ':name', $_POST['name'],
 		  ':type_id', $_POST['type_id'],
 		  ':enabled', $_POST['enabled'],
 		  ':visible', $_POST['visible'],
-		  ':id', $_GET['id']))
+		  ':id', $_GET['id'],
+		  ':domain_id', $domain_id))
 	    {
 			$saved = true;
 			$display_block = "Successfully saved";

--- a/modules/product_attribute/xml.php
+++ b/modules/product_attribute/xml.php
@@ -43,42 +43,35 @@ if (in_array($sort, $validFields)) {
 	$sort = "name";
 }
 
+$domain_id = domain_id::get();
+
 	//$sql = "SELECT * FROM ".TB_PREFIX."customers ORDER BY $sort $dir LIMIT $start, $limit";
-	$sql = "SELECT 
-				id, 
+	$sql = "SELECT
+				id,
 				name,
                 enabled,
                 visible
-			FROM 
+			FROM
 				".TB_PREFIX."products_attributes
-			WHERE 1
+			WHERE domain_id = :domain_id
 				$where
-			ORDER BY 
-				$sort $dir 
-			LIMIT 
+			ORDER BY
+				$sort $dir
+			LIMIT
 				$start, $limit";
 
 	if (empty($query)) {
-		$sth = dbQuery($sql);
+		$sth = dbQuery($sql, ':domain_id', $domain_id);
 	} else {
-		$sth = dbQuery($sql, ':query', "%$query%");
+		$sth = dbQuery($sql, ':domain_id', $domain_id, ':query', "%$query%");
 	}
 
 	$customers = $sth->fetchAll(PDO::FETCH_ASSOC);
-/*
-	$customers = null;
 
-	for($i=0; $customer = $sth->fetch(PDO::FETCH_ASSOC); $i++) {
-		if ($customer['enabled'] == 1) {
-			$customer['enabled'] = {$LANG['enabled']};
-		} else {
-			$customer['enabled'] = {$LANG['disabled']};
-		}
-*/
 global $dbh;
 
-$sqlTotal = "SELECT count(id) AS count FROM ".TB_PREFIX."products_attributes";
-$tth = dbQuery($sqlTotal);
+$sqlTotal = "SELECT count(id) AS count FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+$tth = dbQuery($sqlTotal, ':domain_id', $domain_id);
 $resultCount = $tth->fetch();
 $count = $resultCount[0];
 //echo sql2xml($customers, $count);
@@ -101,20 +94,20 @@ foreach ($customers as $row) {
 	$xml .= "<cell><![CDATA[".$action."]]></cell>";
 	$xml .= "<cell><![CDATA[".utf8_encode($row['name'])."]]></cell>";
 	if ($row['enabled']=='1') {
-		$xml .= "<cell><![CDATA[<img src='images/common/tick.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";				
-	}	
+		$xml .= "<cell><![CDATA[<img src='images/common/tick.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";
+	}
 	else {
-		$xml .= "<cell><![CDATA[<img src='images/common/cross.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";				
+		$xml .= "<cell><![CDATA[<img src='images/common/cross.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";
 	}
 	if ($row['visible']=='1') {
-		$xml .= "<cell><![CDATA[<img src='images/common/tick.png' alt='".$row['visible']."' title='".$row['visible']."' />]]></cell>";				
-	}	
+		$xml .= "<cell><![CDATA[<img src='images/common/tick.png' alt='".$row['visible']."' title='".$row['visible']."' />]]></cell>";
+	}
 	else {
-		$xml .= "<cell><![CDATA[<img src='images/common/cross.png' alt='".$row['visible']."' title='".$row['visible']."' />]]></cell>";				
+		$xml .= "<cell><![CDATA[<img src='images/common/cross.png' alt='".$row['visible']."' title='".$row['visible']."' />]]></cell>";
 	}
 
 
-	$xml .= "</row>";		
+	$xml .= "</row>";
 
 }
 
@@ -124,4 +117,4 @@ $xml .= "</rows>";
 
 echo $xml;
 
-?> 
+?>

--- a/modules/product_value/add.php
+++ b/modules/product_value/add.php
@@ -9,8 +9,9 @@ if ($_POST['value'] !== '' ) {
 	include("./modules/product_value/save.php");
 }
 
-$sql = "SELECT * FROM ".TB_PREFIX."products_attributes";
-$sth =  dbQuery($sql);
+$domain_id = domain_id::get();
+$sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+$sth = dbQuery($sql, ':domain_id', $domain_id);
 $product_attributes = $sth->fetchAll();
 
 $pageActive = "product_value_add";

--- a/modules/product_value/details.php
+++ b/modules/product_value/details.php
@@ -7,16 +7,18 @@ if ($_POST['value'] != "" ) {
 	include("./modules/product_value/save.php");
 }
 
-#get the invoice id
+#get the id
 $id = $_GET['id'];
 
-$sql = "SELECT * FROM ".TB_PREFIX."products_values WHERE id = :id";
-$sth =  dbQuery($sql, ':id', $id);
+$domain_id = domain_id::get();
+
+$sql = "SELECT * FROM ".TB_PREFIX."products_values WHERE id = :id AND domain_id = :domain_id";
+$sth = dbQuery($sql, ':id', $id, ':domain_id', $domain_id);
 $product_value = $sth->fetch();
 $bladeView -> assign("product_value", $product_value);
 
-$sql_attr_sel = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE id = ".$product_value['id'];
-$sth_attr_sel =  dbQuery($sql_attr_sel);
+$sql_attr_sel = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE id = :id AND domain_id = :domain_id";
+$sth_attr_sel = dbQuery($sql_attr_sel, ':id', $product_value['attribute_id'], ':domain_id', $domain_id);
 $product_attribute = $sth_attr_sel->fetch();
 $bladeView -> assign("product_attribute", $product_attribute['name']);
 
@@ -27,8 +29,8 @@ $bladeView -> assign('active_tab', '#product');
 
 $bladeView->assign('preference',$preference);
 
-$sql_attr = "select * from ".TB_PREFIX."products_attributes";
-$sth_attr =  dbquery($sql_attr);
-$product_attributes = $sth_attr->fetchall();
+$sql_attr = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+$sth_attr = dbQuery($sql_attr, ':domain_id', $domain_id);
+$product_attributes = $sth_attr->fetchAll();
 $bladeView -> assign("product_attributes", $product_attributes);
 ?>

--- a/modules/product_value/save.php
+++ b/modules/product_value/save.php
@@ -1,5 +1,5 @@
 <?php
-// -Gates 5/5/2008 added domain_id to parameters 
+// -Gates 5/5/2008 added domain_id to parameters
 //stop the direct browsing to this file - let index.php handle which files get displayed
 checkLogin();
 
@@ -11,17 +11,20 @@ $op = $_POST['op'] ?? null;
 #insert invoice_preference
 if (  $op === 'insert_product_value' ) {
 
+	$domain_id = domain_id::get();
 	$sql = "INSERT into
 		".TB_PREFIX."products_values
+		(domain_id, attribute_id, value, enabled)
 	VALUES
 		(
-			NULL,
+			:domain_id,
 			:attribute_id,
             :value,
             :enabled
 		 )";
 
 	if (dbQuery($sql,
+	  ':domain_id', $domain_id,
 	  ':attribute_id', $_POST['attribute_id'],
 	  ':value', $_POST['value'],
 	  ':enabled', $_POST['enabled']
@@ -43,6 +46,7 @@ if (  $op === 'insert_product_value' ) {
 if (  $op === 'edit_product_value' ) {
 
 	if (isset($_POST['save_product_value'])) {
+		$domain_id = domain_id::get();
 		$sql = "UPDATE
 				".TB_PREFIX."products_values
 			SET
@@ -50,13 +54,15 @@ if (  $op === 'edit_product_value' ) {
 				value = :value,
 				enabled = :enabled
 			WHERE
-				id = :id";
+				id = :id
+			AND domain_id = :domain_id";
 
 		if (dbQuery($sql,
 		  ':attribute_id', $_POST['attribute_id'],
 		  ':value', $_POST['value'],
 		  ':enabled', $_POST['enabled'],
-		  ':id', $_GET['id']))
+		  ':id', $_GET['id'],
+		  ':domain_id', $domain_id))
 	    {
 			$saved = true;
 			$display_block = "Successfully saved";

--- a/modules/product_value/xml.php
+++ b/modules/product_value/xml.php
@@ -43,41 +43,33 @@ if (in_array($sort, $validFields)) {
 	$sort = "name";
 }
 
-	$sql = "SELECT 
-				v.id as id, 
+$domain_id = domain_id::get();
+
+	$sql = "SELECT
+				v.id as id,
 				a.name as name,
                 v.value as value,
                 v.enabled as enabled
-			FROM 
+			FROM
 				".TB_PREFIX."products_attributes a LEFT JOIN
 				".TB_PREFIX."products_values v ON (a.id = v.attribute_id)
-			WHERE 1
+			WHERE a.domain_id = :domain_id
 				$where
-			ORDER BY 
-				$sort $dir 
-			LIMIT 
+			ORDER BY
+				$sort $dir
+			LIMIT
 				$start, $limit";
 
 	if (empty($query)) {
-		$sth = dbQuery($sql);
+		$sth = dbQuery($sql, ':domain_id', $domain_id);
 	} else {
-		$sth = dbQuery($sql, ':query', "%$query%");
+		$sth = dbQuery($sql, ':domain_id', $domain_id, ':query', "%$query%");
 	}
 
 	$customers = $sth->fetchAll(PDO::FETCH_ASSOC);
-/*
-	$customers = null;
 
-	for($i=0; $customer = $sth->fetch(PDO::FETCH_ASSOC); $i++) {
-		if ($customer['enabled'] == 1) {
-			$customer['enabled'] = {$LANG['enabled']};
-		} else {
-			$customer['enabled'] = {$LANG['disabled']};
-		}
-*/
-
-$sqlTotal = "SELECT count(id) AS count FROM ".TB_PREFIX."products_values";
-$tth = dbQuery($sqlTotal);
+$sqlTotal = "SELECT count(id) AS count FROM ".TB_PREFIX."products_values WHERE domain_id = :domain_id";
+$tth = dbQuery($sqlTotal, ':domain_id', $domain_id);
 $resultCount = $tth->fetch();
 $count = $resultCount[0];
 //echo sql2xml($customers, $count);
@@ -102,14 +94,14 @@ foreach ($customers as $row) {
 	$xml .= "<cell><![CDATA[".utf8_encode($row['name'])."]]></cell>";
 	$xml .= "<cell><![CDATA[".utf8_encode($row['value'])."]]></cell>";
 	if ($row['enabled']=='1') {
-		$xml .= "<cell><![CDATA[<img src='images/common/tick.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";				
-	}	
+		$xml .= "<cell><![CDATA[<img src='images/common/tick.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";
+	}
 	else {
-		$xml .= "<cell><![CDATA[<img src='images/common/cross.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";				
+		$xml .= "<cell><![CDATA[<img src='images/common/cross.png' alt='".$row['enabled']."' title='".$row['enabled']."' />]]></cell>";
 	}
 
 
-	$xml .= "</row>";		
+	$xml .= "</row>";
 
 }
 
@@ -119,4 +111,4 @@ $xml .= "</rows>";
 
 echo $xml;
 
-?> 
+?>

--- a/modules/products/add.php
+++ b/modules/products/add.php
@@ -16,8 +16,9 @@ $bladeView -> assign('customFieldLabel',$customFieldLabel);
 $bladeView -> assign('save',$save);
 $bladeView -> assign('taxes',$taxes);
 
-$sql = "select * from ".TB_PREFIX."products_attributes where enabled ='1'";
-$sth =  dbQuery($sql);
+$domain_id = domain_id::get();
+$sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE enabled = '1' AND domain_id = :domain_id";
+$sth = dbQuery($sql, ':domain_id', $domain_id);
 $attributes = $sth->fetchAll();
 
 $bladeView -> assign("attributes", $attributes);

--- a/modules/products/details.php
+++ b/modules/products/details.php
@@ -19,8 +19,9 @@ $bladeView -> assign('taxes',$taxes);
 $bladeView -> assign('tax_selected',$tax_selected);
 $bladeView -> assign('customFieldLabel',$customFieldLabel);
 
-$sql = "select * from ".TB_PREFIX."products_attributes";
-$sth =  dbQuery($sql);
+$domain_id = domain_id::get();
+$sql = "SELECT * FROM ".TB_PREFIX."products_attributes WHERE domain_id = :domain_id";
+$sth = dbQuery($sql, ':domain_id', $domain_id);
 $attributes = $sth->fetchAll();
 $bladeView -> assign("attributes", $attributes);
 


### PR DESCRIPTION
## Summary
This PR implements multi-tenancy support for product attributes and product values by adding `domain_id` filtering throughout the codebase. This ensures that each domain/tenant only sees and manages their own product attributes and values.

## Key Changes

- **Database Schema Updates**
  - Added `domain_id` column to `si_products_attributes` table with default value of 1
  - Added `domain_id` column to `si_products_values` table with default value of 1
  - Created indexes on `domain_id` columns for both tables in MySQL, PostgreSQL, and SQLite
  - Added SQL patches (330 and 331) to handle database migrations across different database adapters

- **Query Updates**
  - Updated all SELECT queries in product attribute and value modules to filter by `domain_id`
  - Updated INSERT queries to include `domain_id` from the current domain context
  - Updated UPDATE queries to include `domain_id` in WHERE clauses for data isolation
  - Modified JOIN conditions to ensure domain consistency between related tables

- **Module Updates**
  - `modules/product_attribute/xml.php`: Added domain filtering to attribute listing and count queries
  - `modules/product_value/xml.php`: Added domain filtering to value listing and count queries
  - `modules/product_attribute/details.php`: Added domain filtering to attribute retrieval
  - `modules/product_attribute/save.php`: Added domain_id to insert and update operations
  - `modules/product_value/details.php`: Added domain filtering to value and attribute queries
  - `modules/product_value/save.php`: Added domain_id to insert and update operations
  - `modules/product_value/add.php`: Added domain filtering to attribute selection
  - `modules/products/add.php` and `details.php`: Added domain filtering to attribute queries
  - `modules/invoices/details.php`: Added domain filtering to attribute and value lookups
  - `modules/invoices/product_ajax.php`: Added domain filtering and parameterized queries
  - `modules/invoices/invoice.php`: Added domain filtering to attribute matrix queries
  - `modules/invoices/quick_view.php`: Added domain filtering to attribute queries
  - `include/class/product/attributes.php`: Added domain filtering to all attribute retrieval methods
  - `include/sql_queries.php`: Added domain filtering to product attribute queries

- **API Updates**
  - `modules/api/ach.php`: Modified to resolve domain_id from the referenced invoice instead of hardcoding to '1'

- **Code Quality**
  - Converted sprintf-based SQL queries to parameterized queries for better security
  - Standardized SQL formatting (uppercase keywords, consistent indentation)
  - Removed trailing whitespace and fixed formatting inconsistencies
  - Removed commented-out legacy code blocks

## Implementation Details

- All queries now use parameterized bindings (`:domain_id`) to prevent SQL injection
- The `domain_id::get()` method is called to retrieve the current domain context
- Default domain_id value of 1 is used for backward compatibility with existing data
- JOIN conditions between `products_attributes` and `products_values` now explicitly match on both `attribute_id` and `domain_id` to ensure data consistency
- The ACH payment module now dynamically resolves the domain_id from the referenced invoice rather than assuming domain 1

https://claude.ai/code/session_01JhNRuWEmcr8yhPzV4p5C4i