### PR TITLE
Add domain admin UI for managing customer and biller login accounts

### DIFF
--- a/include/acl.php
+++ b/include/acl.php
@@ -79,6 +79,7 @@ $acl->addRole('biller');
 
 //create the resources
 $acl->addResource('admin');
+$acl->addResource('domain_admin');
 $acl->addResource('api');
 $acl->addResource('auth');
 $acl->addResource('billers');
@@ -123,7 +124,13 @@ $acl->allow('operator', 'billers', 'view');
 $acl->allow('operator', 'customers', 'manage');
 $acl->allow('operator', 'customers', 'view');
 
-// deny rules — admin panel is administrator-only
+// deny rules — admin panel is administrator-only; domain_admin for domain_administrator+administrator
+$acl->deny('user', 'domain_admin');
+$acl->deny('operator', 'domain_admin');
+$acl->deny('viewer', 'domain_admin');
+$acl->deny('customer', 'domain_admin');
+$acl->deny('biller', 'domain_admin');
+
 $acl->deny('domain_administrator', 'admin');
 $acl->deny('user', 'admin');
 $acl->deny('operator', 'admin');

--- a/modules/domain_admin/index.php
+++ b/modules/domain_admin/index.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Script: domain_admin/index.php
+ *   Domain admin dashboard — domain_administrator and administrator roles only
+ *
+ * License: GPL v3 or above
+ */
+
+checkLogin();
+
+$allowed_roles = ['administrator', 'domain_administrator'];
+if (!in_array($auth_session->role_name ?? '', $allowed_roles, true)) {
+    exit($LANG['denied_page'] ?? 'Access Denied');
+}
+
+$domain_id = (int) $auth_session->domain_id;
+
+// Count customer users in this domain
+$sth = dbQuery(
+    "SELECT COUNT(*) AS cnt
+     FROM " . TB_PREFIX . "user u
+     JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+     WHERE u.domain_id = :domain_id AND r.name = 'customer'",
+    ':domain_id', $domain_id
+);
+$customerUserCount = (int) ($sth->fetch(PDO::FETCH_ASSOC)['cnt'] ?? 0);
+
+// Count biller users in this domain
+$sth = dbQuery(
+    "SELECT COUNT(*) AS cnt
+     FROM " . TB_PREFIX . "user u
+     JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+     WHERE u.domain_id = :domain_id AND r.name = 'biller'",
+    ':domain_id', $domain_id
+);
+$billerUserCount = (int) ($sth->fetch(PDO::FETCH_ASSOC)['cnt'] ?? 0);
+
+// Count unlinked customers (no login account yet)
+$sth = dbQuery(
+    "SELECT COUNT(*) AS cnt
+     FROM " . TB_PREFIX . "customers c
+     WHERE c.domain_id = :domain_id AND c.enabled = 1
+       AND NOT EXISTS (
+           SELECT 1 FROM " . TB_PREFIX . "user u
+           JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+           WHERE r.name = 'customer' AND u.user_id = c.id AND u.domain_id = :domain_id2
+       )",
+    ':domain_id', $domain_id,
+    ':domain_id2', $domain_id
+);
+$unlinkedCustomers = (int) ($sth->fetch(PDO::FETCH_ASSOC)['cnt'] ?? 0);
+
+// Count unlinked billers
+$sth = dbQuery(
+    "SELECT COUNT(*) AS cnt
+     FROM " . TB_PREFIX . "biller b
+     WHERE b.domain_id = :domain_id AND b.enabled = 1
+       AND NOT EXISTS (
+           SELECT 1 FROM " . TB_PREFIX . "user u
+           JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+           WHERE r.name = 'biller' AND u.user_id = b.id AND u.domain_id = :domain_id2
+       )",
+    ':domain_id', $domain_id,
+    ':domain_id2', $domain_id
+);
+$unlinkedBillers = (int) ($sth->fetch(PDO::FETCH_ASSOC)['cnt'] ?? 0);
+
+$bladeView->assign('customerUserCount', $customerUserCount);
+$bladeView->assign('billerUserCount', $billerUserCount);
+$bladeView->assign('unlinkedCustomers', $unlinkedCustomers);
+$bladeView->assign('unlinkedBillers', $unlinkedBillers);
+$bladeView->assign('pageActive', 'domain_admin');

--- a/modules/domain_admin/user_add.php
+++ b/modules/domain_admin/user_add.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Script: domain_admin/user_add.php
+ *   Create a customer or biller login account linked to an existing entity
+ *
+ * License: GPL v3 or above
+ */
+
+checkLogin();
+
+$allowed_roles = ['administrator', 'domain_administrator'];
+if (!in_array($auth_session->role_name ?? '', $allowed_roles, true)) {
+    exit($LANG['denied_page'] ?? 'Access Denied');
+}
+
+$domain_id = (int) $auth_session->domain_id;
+
+if (!empty($_POST['email'])) {
+    include './modules/domain_admin/user_save.php';
+}
+
+// Customers in this domain (enabled)
+$sth = dbQuery(
+    "SELECT id, name FROM " . TB_PREFIX . "customers
+     WHERE domain_id = :domain_id AND enabled = 1
+     ORDER BY name",
+    ':domain_id', $domain_id
+);
+$customers = $sth->fetchAll(PDO::FETCH_ASSOC);
+
+// Billers in this domain (enabled)
+$sth = dbQuery(
+    "SELECT id, name FROM " . TB_PREFIX . "biller
+     WHERE domain_id = :domain_id AND enabled = 1
+     ORDER BY name",
+    ':domain_id', $domain_id
+);
+$billers = $sth->fetchAll(PDO::FETCH_ASSOC);
+
+$bladeView->assign('customers', $customers);
+$bladeView->assign('billers', $billers);
+$bladeView->assign('domainUserSaveCsrfToken', siNonce('domain_user_save'));
+$bladeView->assign('pageActive', 'domain_admin');

--- a/modules/domain_admin/user_edit.php
+++ b/modules/domain_admin/user_edit.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Script: domain_admin/user_edit.php
+ *   Edit a customer or biller login account
+ *
+ * License: GPL v3 or above
+ */
+
+checkLogin();
+
+$allowed_roles = ['administrator', 'domain_administrator'];
+if (!in_array($auth_session->role_name ?? '', $allowed_roles, true)) {
+    exit($LANG['denied_page'] ?? 'Access Denied');
+}
+
+$domain_id = (int) $auth_session->domain_id;
+$id        = (int) ($_GET['id'] ?? 0);
+
+if ($id < 1) {
+    header('Location: index.php?module=domain_admin&view=users');
+    exit();
+}
+
+if (!empty($_POST['email'])) {
+    include './modules/domain_admin/user_save.php';
+} else {
+    // Load the user — must belong to this domain and be customer or biller role
+    $sth = dbQuery(
+        "SELECT u.id, u.email, u.name, u.enabled, u.user_id, u.role_id,
+                r.name AS role_name
+         FROM " . TB_PREFIX . "user u
+         JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+         WHERE u.id = :id AND u.domain_id = :domain_id
+           AND r.name IN ('customer', 'biller')",
+        ':id', $id,
+        ':domain_id', $domain_id
+    );
+    $domainUser = $sth->fetch(PDO::FETCH_ASSOC);
+
+    if (!$domainUser) {
+        header('Location: index.php?module=domain_admin&view=users');
+        exit();
+    }
+    $bladeView->assign('domainUser', $domainUser);
+}
+
+// Customers in this domain (enabled)
+$sth = dbQuery(
+    "SELECT id, name FROM " . TB_PREFIX . "customers
+     WHERE domain_id = :domain_id AND enabled = 1
+     ORDER BY name",
+    ':domain_id', $domain_id
+);
+$customers = $sth->fetchAll(PDO::FETCH_ASSOC);
+
+// Billers in this domain (enabled)
+$sth = dbQuery(
+    "SELECT id, name FROM " . TB_PREFIX . "biller
+     WHERE domain_id = :domain_id AND enabled = 1
+     ORDER BY name",
+    ':domain_id', $domain_id
+);
+$billers = $sth->fetchAll(PDO::FETCH_ASSOC);
+
+$bladeView->assign('customers', $customers);
+$bladeView->assign('billers', $billers);
+$bladeView->assign('domainUserSaveCsrfToken', siNonce('domain_user_save'));
+$bladeView->assign('pageActive', 'domain_admin');

--- a/modules/domain_admin/user_save.php
+++ b/modules/domain_admin/user_save.php
@@ -1,0 +1,157 @@
+<?php
+/*
+ * Script: domain_admin/user_save.php
+ *   Insert / update a customer or biller login account
+ *   Included by user_add.php and user_edit.php
+ *
+ * License: GPL v3 or above
+ */
+
+checkLogin();
+
+$allowed_roles = ['administrator', 'domain_administrator'];
+if (!in_array($auth_session->role_name ?? '', $allowed_roles, true)) {
+    exit($LANG['denied_page'] ?? 'Access Denied');
+}
+
+require_once __DIR__ . '/../../include/auth/password.php';
+
+$domain_id = (int) $auth_session->domain_id;
+$op        = !empty($_POST['op']) ? preg_replace('/[^a-z_]/', '', (string) $_POST['op']) : null;
+$saved     = false;
+$saveError = null;
+
+// Role IDs for customer and biller (fixed — only these two are manageable here)
+$allowed_role_map = ['customer' => 5, 'biller' => 6];
+
+if ($op === 'insert_domain_user') {
+    requireCSRFProtection('domain_user_save');
+
+    $email        = trim((string) ($_POST['email'] ?? ''));
+    $name         = trim((string) ($_POST['name'] ?? ''));
+    $password     = (string) ($_POST['password_field'] ?? '');
+    $role_key     = in_array($_POST['role_key'] ?? '', ['customer', 'biller'], true)
+                    ? $_POST['role_key'] : null;
+    $linked_id    = (int) ($_POST['linked_id'] ?? 0);
+    $enabled      = (int) ($_POST['enabled'] ?? 1);
+
+    if (!$email) {
+        $saveError = 'Email is required.';
+    } elseif (!$role_key) {
+        $saveError = 'Role must be customer or biller.';
+    } elseif ($linked_id < 1) {
+        $saveError = 'Please select a customer or biller to link.';
+    } elseif (!$password) {
+        $saveError = 'Password is required for new accounts.';
+    } else {
+        // Verify the linked entity belongs to this domain
+        $table  = $role_key === 'customer' ? TB_PREFIX . 'customers' : TB_PREFIX . 'biller';
+        $check  = dbQuery("SELECT id FROM {$table} WHERE id = :id AND domain_id = :domain_id",
+                          ':id', $linked_id, ':domain_id', $domain_id);
+        if (!$check->fetch()) {
+            $saveError = 'Selected ' . $role_key . ' does not exist in your domain.';
+        } else {
+            $role_id      = $allowed_role_map[$role_key];
+            $passwordHash = auth_hash_password($password);
+            $sth = dbQuery(
+                "INSERT INTO " . TB_PREFIX . "user
+                 (email, name, password, role_id, domain_id, enabled, user_id)
+                 VALUES (:email, :name, :password, :role_id, :domain_id, :enabled, :user_id)",
+                ':email',     $email,
+                ':name',      $name,
+                ':password',  $passwordHash,
+                ':role_id',   $role_id,
+                ':domain_id', $domain_id,
+                ':enabled',   $enabled,
+                ':user_id',   $linked_id
+            );
+            if ($sth) {
+                $saved = true;
+            } else {
+                $saveError = 'Could not create account — the email address may already be in use.';
+            }
+        }
+    }
+}
+
+if ($op === 'update_domain_user') {
+    requireCSRFProtection('domain_user_save');
+
+    $id           = (int) ($_POST['id'] ?? 0);
+    $email        = trim((string) ($_POST['email'] ?? ''));
+    $name         = trim((string) ($_POST['name'] ?? ''));
+    $password     = trim((string) ($_POST['password_field'] ?? ''));
+    $role_key     = in_array($_POST['role_key'] ?? '', ['customer', 'biller'], true)
+                    ? $_POST['role_key'] : null;
+    $linked_id    = (int) ($_POST['linked_id'] ?? 0);
+    $enabled      = (int) ($_POST['enabled'] ?? 1);
+
+    if ($id < 1 || !$email) {
+        $saveError = 'Invalid request.';
+    } elseif (!$role_key) {
+        $saveError = 'Role must be customer or biller.';
+    } elseif ($linked_id < 1) {
+        $saveError = 'Please select a customer or biller to link.';
+    } else {
+        // Confirm the user belongs to this domain and is customer/biller
+        $sth = dbQuery(
+            "SELECT u.id FROM " . TB_PREFIX . "user u
+             JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+             WHERE u.id = :id AND u.domain_id = :domain_id AND r.name IN ('customer','biller')",
+            ':id', $id, ':domain_id', $domain_id
+        );
+        if (!$sth->fetch()) {
+            $saveError = 'User not found in your domain.';
+        } else {
+            // Verify linked entity is in this domain
+            $table = $role_key === 'customer' ? TB_PREFIX . 'customers' : TB_PREFIX . 'biller';
+            $check = dbQuery("SELECT id FROM {$table} WHERE id = :id AND domain_id = :domain_id",
+                             ':id', $linked_id, ':domain_id', $domain_id);
+            if (!$check->fetch()) {
+                $saveError = 'Selected ' . $role_key . ' does not exist in your domain.';
+            } else {
+                $role_id = $allowed_role_map[$role_key];
+
+                if ($password !== '') {
+                    $passwordHash = auth_hash_password($password);
+                    $sth = dbQuery(
+                        "UPDATE " . TB_PREFIX . "user
+                         SET email=:email, name=:name, password=:password,
+                             role_id=:role_id, enabled=:enabled, user_id=:user_id
+                         WHERE id=:id AND domain_id=:domain_id",
+                        ':email',     $email,
+                        ':name',      $name,
+                        ':password',  $passwordHash,
+                        ':role_id',   $role_id,
+                        ':enabled',   $enabled,
+                        ':user_id',   $linked_id,
+                        ':id',        $id,
+                        ':domain_id', $domain_id
+                    );
+                } else {
+                    $sth = dbQuery(
+                        "UPDATE " . TB_PREFIX . "user
+                         SET email=:email, name=:name,
+                             role_id=:role_id, enabled=:enabled, user_id=:user_id
+                         WHERE id=:id AND domain_id=:domain_id",
+                        ':email',     $email,
+                        ':name',      $name,
+                        ':role_id',   $role_id,
+                        ':enabled',   $enabled,
+                        ':user_id',   $linked_id,
+                        ':id',        $id,
+                        ':domain_id', $domain_id
+                    );
+                }
+                $saved = $sth ? true : false;
+                if (!$saved) {
+                    $saveError = 'Could not update account — the email may already be in use.';
+                }
+            }
+        }
+    }
+}
+
+$bladeView->assign('saved',     $saved);
+$bladeView->assign('saveError', $saveError);
+$bladeView->assign('pageActive', 'domain_admin');

--- a/modules/domain_admin/users.php
+++ b/modules/domain_admin/users.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Script: domain_admin/users.php
+ *   List customer and biller login accounts in this domain
+ *
+ * License: GPL v3 or above
+ */
+
+checkLogin();
+
+$allowed_roles = ['administrator', 'domain_administrator'];
+if (!in_array($auth_session->role_name ?? '', $allowed_roles, true)) {
+    exit($LANG['denied_page'] ?? 'Access Denied');
+}
+
+$domain_id = (int) $auth_session->domain_id;
+
+$sth = dbQuery(
+    "SELECT u.id, u.email, u.name, u.enabled, u.user_id,
+            r.name AS role_name,
+            c.name AS customer_name,
+            b.name  AS biller_name
+     FROM " . TB_PREFIX . "user u
+     JOIN " . TB_PREFIX . "user_role r ON u.role_id = r.id
+     LEFT JOIN " . TB_PREFIX . "customers c
+          ON r.name = 'customer' AND c.domain_id = u.domain_id AND c.id = u.user_id
+     LEFT JOIN " . TB_PREFIX . "biller b
+          ON r.name = 'biller' AND b.domain_id = u.domain_id AND b.id = u.user_id
+     WHERE u.domain_id = :domain_id
+       AND r.name IN ('customer', 'biller')
+     ORDER BY r.name, u.name",
+    ':domain_id', $domain_id
+);
+$domainUsers = $sth->fetchAll(PDO::FETCH_ASSOC);
+
+$bladeView->assign('domainUsers', $domainUsers);
+$bladeView->assign('pageActive', 'domain_admin');

--- a/templates/default/domain_admin/index.blade.php
+++ b/templates/default/domain_admin/index.blade.php
@@ -1,0 +1,105 @@
+{{-- Domain Admin dashboard --}}
+<div class="row row-cards mb-3">
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">Customer Accounts</div>
+                <div class="h1 mb-3">{{ $customerUserCount }}</div>
+                <a href="index.php?module=domain_admin&view=users&filter=customer" class="btn btn-sm btn-outline-primary">
+                    <i class="ti ti-users me-1"></i>View
+                </a>
+                <a href="index.php?module=domain_admin&view=user_add&role=customer" class="btn btn-sm btn-primary ms-1">
+                    <i class="ti ti-plus me-1"></i>Add
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">Biller Accounts</div>
+                <div class="h1 mb-3">{{ $billerUserCount }}</div>
+                <a href="index.php?module=domain_admin&view=users&filter=biller" class="btn btn-sm btn-outline-primary">
+                    <i class="ti ti-users me-1"></i>View
+                </a>
+                <a href="index.php?module=domain_admin&view=user_add&role=biller" class="btn btn-sm btn-primary ms-1">
+                    <i class="ti ti-plus me-1"></i>Add
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">Customers without Login</div>
+                <div class="h1 mb-3 @if($unlinkedCustomers > 0) text-warning @endif">{{ $unlinkedCustomers }}</div>
+                @if($unlinkedCustomers > 0)
+                <a href="index.php?module=domain_admin&view=user_add&role=customer" class="btn btn-sm btn-warning">
+                    <i class="ti ti-plus me-1"></i>Create Logins
+                </a>
+                @endif
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="subheader">Billers without Login</div>
+                <div class="h1 mb-3 @if($unlinkedBillers > 0) text-warning @endif">{{ $unlinkedBillers }}</div>
+                @if($unlinkedBillers > 0)
+                <a href="index.php?module=domain_admin&view=user_add&role=biller" class="btn btn-sm btn-warning">
+                    <i class="ti ti-plus me-1"></i>Create Logins
+                </a>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Domain Admin Actions</h3>
+    </div>
+    <div class="list-group list-group-flush">
+        <a href="index.php?module=domain_admin&view=users" class="list-group-item list-group-item-action">
+            <div class="row align-items-center">
+                <div class="col-auto"><span class="avatar bg-blue-lt"><i class="ti ti-users"></i></span></div>
+                <div class="col">
+                    <div class="fw-medium">Manage Login Accounts</div>
+                    <div class="text-secondary small">View, edit, or disable customer and biller login accounts</div>
+                </div>
+                <div class="col-auto text-secondary"><i class="ti ti-chevron-right"></i></div>
+            </div>
+        </a>
+        <a href="index.php?module=domain_admin&view=user_add" class="list-group-item list-group-item-action">
+            <div class="row align-items-center">
+                <div class="col-auto"><span class="avatar bg-green-lt"><i class="ti ti-user-plus"></i></span></div>
+                <div class="col">
+                    <div class="fw-medium">Add Login Account</div>
+                    <div class="text-secondary small">Create a login for an existing customer or biller</div>
+                </div>
+                <div class="col-auto text-secondary"><i class="ti ti-chevron-right"></i></div>
+            </div>
+        </a>
+        <a href="index.php?module=customers&view=manage" class="list-group-item list-group-item-action">
+            <div class="row align-items-center">
+                <div class="col-auto"><span class="avatar bg-purple-lt"><i class="ti ti-address-book"></i></span></div>
+                <div class="col">
+                    <div class="fw-medium">Manage Customers</div>
+                    <div class="text-secondary small">Add or edit customer records in this domain</div>
+                </div>
+                <div class="col-auto text-secondary"><i class="ti ti-chevron-right"></i></div>
+            </div>
+        </a>
+        <a href="index.php?module=billers&view=manage" class="list-group-item list-group-item-action">
+            <div class="row align-items-center">
+                <div class="col-auto"><span class="avatar bg-orange-lt"><i class="ti ti-building-store"></i></span></div>
+                <div class="col">
+                    <div class="fw-medium">Manage Billers</div>
+                    <div class="text-secondary small">Add or edit biller records in this domain</div>
+                </div>
+                <div class="col-auto text-secondary"><i class="ti ti-chevron-right"></i></div>
+            </div>
+        </a>
+    </div>
+</div>

--- a/templates/default/domain_admin/user_add.blade.php
+++ b/templates/default/domain_admin/user_add.blade.php
@@ -1,0 +1,126 @@
+{{-- Domain Admin: add customer or biller login account --}}
+@if(!empty($_POST['email']) && form_submitted())
+    @include('templates.default.domain_admin.user_save')
+@else
+
+@php $presetRole = get('role') ?? 'customer'; @endphp
+
+<form method="post" action="index.php?module=domain_admin&view=user_add"
+      class="needs-validation" novalidate id="domainUserForm">
+<div class="card">
+    <div class="card-body">
+
+        {{-- Role selector --}}
+        <div class="mb-3">
+            <label class="form-label fw-medium">Account Type <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
+            <div class="d-flex gap-3">
+                <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="role_key" value="customer"
+                           @if($presetRole !== 'biller') checked @endif
+                           onchange="toggleLinkedDropdown(this.value)">
+                    <span class="form-check-label">
+                        <i class="ti ti-address-book me-1"></i>Customer
+                    </span>
+                </label>
+                <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="role_key" value="biller"
+                           @if($presetRole === 'biller') checked @endif
+                           onchange="toggleLinkedDropdown(this.value)">
+                    <span class="form-check-label">
+                        <i class="ti ti-building-store me-1"></i>Biller
+                    </span>
+                </label>
+            </div>
+        </div>
+
+        {{-- Link to customer --}}
+        <div class="mb-3" id="customerDropdown" @if($presetRole === 'biller') style="display:none" @endif>
+            <label class="form-label">Link to Customer <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
+            <select name="linked_id" id="linked_id_customer" class="form-select">
+                <option value="">— select customer —</option>
+                @foreach(($customers ?? []) as $c)
+                    <option value="{{ $c['id'] }}">{{ $c['name'] }}</option>
+                @endforeach
+            </select>
+            @if(empty($customers))
+                <div class="form-hint text-warning">No enabled customers found in this domain.</div>
+            @endif
+        </div>
+
+        {{-- Link to biller --}}
+        <div class="mb-3" id="billerDropdown" @if($presetRole !== 'biller') style="display:none" @endif>
+            <label class="form-label">Link to Biller <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
+            <select name="linked_id_biller" id="linked_id_biller" class="form-select">
+                <option value="">— select biller —</option>
+                @foreach(($billers ?? []) as $b)
+                    <option value="{{ $b['id'] }}">{{ $b['name'] }}</option>
+                @endforeach
+            </select>
+            @if(empty($billers))
+                <div class="form-hint text-warning">No enabled billers found in this domain.</div>
+            @endif
+        </div>
+
+        <hr class="my-3">
+
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" value="{{ post('name') }}" class="form-control" autocomplete="off" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
+            <input type="email" name="email" value="{{ post('email') }}" class="form-control"
+                   required autocomplete="off" />
+            <div class="invalid-feedback">A valid email is required.</div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
+            <input type="password" name="password_field" class="form-control"
+                   required autocomplete="new-password" />
+            <div class="invalid-feedback">Password is required.</div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="enabled" class="form-select">
+                <option value="1" selected>Enabled</option>
+                <option value="0">Disabled</option>
+            </select>
+        </div>
+    </div>
+    <div class="card-footer">
+        <div class="d-flex">
+            <a href="index.php?module=domain_admin&view=users" class="btn btn-link">Cancel</a>
+            <button type="submit" class="btn btn-primary ms-auto">
+                <i class="ti ti-check me-1"></i>Create Account
+            </button>
+        </div>
+    </div>
+</div>
+<input type="hidden" name="op" value="insert_domain_user" />
+<input type="hidden" name="csrfprotectionbysr" value="{{ $domainUserSaveCsrfToken ?? '' }}" />
+</form>
+
+<script>
+function toggleLinkedDropdown(role) {
+    var customerDiv = document.getElementById('customerDropdown');
+    var billerDiv   = document.getElementById('billerDropdown');
+    if (role === 'biller') {
+        customerDiv.style.display = 'none';
+        billerDiv.style.display   = '';
+    } else {
+        customerDiv.style.display = '';
+        billerDiv.style.display   = 'none';
+    }
+}
+
+// Before submit: copy the visible linked_id into the hidden field the server reads
+document.getElementById('domainUserForm').addEventListener('submit', function() {
+    var role = document.querySelector('input[name="role_key"]:checked').value;
+    var src  = role === 'biller'
+               ? document.getElementById('linked_id_biller')
+               : document.getElementById('linked_id_customer');
+    src.name = 'linked_id';
+});
+</script>
+
+@endif

--- a/templates/default/domain_admin/user_add.blade.php
+++ b/templates/default/domain_admin/user_add.blade.php
@@ -33,10 +33,14 @@
             </div>
         </div>
 
+        {{-- Hidden field that carries the selected entity id --}}
+        <input type="hidden" name="linked_id" id="linked_id_hidden" value="" />
+
         {{-- Link to customer --}}
         <div class="mb-3" id="customerDropdown" @if($presetRole === 'biller') style="display:none" @endif>
             <label class="form-label">Link to Customer <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
-            <select name="linked_id" id="linked_id_customer" class="form-select">
+            <select id="linked_id_customer" class="form-select"
+                    onchange="syncLinkedId()">
                 <option value="">— select customer —</option>
                 @foreach(($customers ?? []) as $c)
                     <option value="{{ $c['id'] }}">{{ $c['name'] }}</option>
@@ -50,7 +54,8 @@
         {{-- Link to biller --}}
         <div class="mb-3" id="billerDropdown" @if($presetRole !== 'biller') style="display:none" @endif>
             <label class="form-label">Link to Biller <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
-            <select name="linked_id_biller" id="linked_id_biller" class="form-select">
+            <select id="linked_id_biller" class="form-select"
+                    onchange="syncLinkedId()">
                 <option value="">— select biller —</option>
                 @foreach(($billers ?? []) as $b)
                     <option value="{{ $b['id'] }}">{{ $b['name'] }}</option>
@@ -90,7 +95,7 @@
     <div class="card-footer">
         <div class="d-flex">
             <a href="index.php?module=domain_admin&view=users" class="btn btn-link">Cancel</a>
-            <button type="submit" class="btn btn-primary ms-auto">
+            <button type="submit" name="submit" class="btn btn-primary ms-auto">
                 <i class="ti ti-check me-1"></i>Create Account
             </button>
         </div>
@@ -101,6 +106,14 @@
 </form>
 
 <script>
+function syncLinkedId() {
+    var role = document.querySelector('input[name="role_key"]:checked').value;
+    var src  = role === 'biller'
+               ? document.getElementById('linked_id_biller')
+               : document.getElementById('linked_id_customer');
+    document.getElementById('linked_id_hidden').value = src ? src.value : '';
+}
+
 function toggleLinkedDropdown(role) {
     var customerDiv = document.getElementById('customerDropdown');
     var billerDiv   = document.getElementById('billerDropdown');
@@ -111,16 +124,11 @@ function toggleLinkedDropdown(role) {
         customerDiv.style.display = '';
         billerDiv.style.display   = 'none';
     }
+    syncLinkedId();
 }
 
-// Before submit: copy the visible linked_id into the hidden field the server reads
-document.getElementById('domainUserForm').addEventListener('submit', function() {
-    var role = document.querySelector('input[name="role_key"]:checked').value;
-    var src  = role === 'biller'
-               ? document.getElementById('linked_id_biller')
-               : document.getElementById('linked_id_customer');
-    src.name = 'linked_id';
-});
+// Sync on page load so the hidden field has a value from the start
+document.addEventListener('DOMContentLoaded', syncLinkedId);
 </script>
 
 @endif

--- a/templates/default/domain_admin/user_edit.blade.php
+++ b/templates/default/domain_admin/user_edit.blade.php
@@ -37,10 +37,13 @@
             </div>
         </div>
 
+        {{-- Hidden field that carries the selected entity id --}}
+        <input type="hidden" name="linked_id" id="linked_id_hidden" value="{{ $curId ?: '' }}" />
+
         {{-- Link to customer --}}
         <div class="mb-3" id="customerDropdown" @if($curRole === 'biller') style="display:none" @endif>
             <label class="form-label">Link to Customer</label>
-            <select name="linked_id" id="linked_id_customer" class="form-select">
+            <select id="linked_id_customer" class="form-select" onchange="syncLinkedId()">
                 <option value="">— select customer —</option>
                 @foreach(($customers ?? []) as $c)
                     <option value="{{ $c['id'] }}"
@@ -54,7 +57,7 @@
         {{-- Link to biller --}}
         <div class="mb-3" id="billerDropdown" @if($curRole !== 'biller') style="display:none" @endif>
             <label class="form-label">Link to Biller</label>
-            <select name="linked_id_biller" id="linked_id_biller" class="form-select">
+            <select id="linked_id_biller" class="form-select" onchange="syncLinkedId()">
                 <option value="">— select biller —</option>
                 @foreach(($billers ?? []) as $b)
                     <option value="{{ $b['id'] }}"
@@ -94,7 +97,7 @@
     <div class="card-footer">
         <div class="d-flex">
             <a href="index.php?module=domain_admin&view=users" class="btn btn-link">Cancel</a>
-            <button type="submit" class="btn btn-primary ms-auto">
+            <button type="submit" name="submit" class="btn btn-primary ms-auto">
                 <i class="ti ti-check me-1"></i>Save Changes
             </button>
         </div>
@@ -106,6 +109,14 @@
 </form>
 
 <script>
+function syncLinkedId() {
+    var role = document.querySelector('input[name="role_key"]:checked').value;
+    var src  = role === 'biller'
+               ? document.getElementById('linked_id_biller')
+               : document.getElementById('linked_id_customer');
+    document.getElementById('linked_id_hidden').value = src ? src.value : '';
+}
+
 function toggleLinkedDropdown(role) {
     var customerDiv = document.getElementById('customerDropdown');
     var billerDiv   = document.getElementById('billerDropdown');
@@ -116,15 +127,10 @@ function toggleLinkedDropdown(role) {
         customerDiv.style.display = '';
         billerDiv.style.display   = 'none';
     }
+    syncLinkedId();
 }
 
-document.getElementById('domainUserForm').addEventListener('submit', function() {
-    var role = document.querySelector('input[name="role_key"]:checked').value;
-    var src  = role === 'biller'
-               ? document.getElementById('linked_id_biller')
-               : document.getElementById('linked_id_customer');
-    src.name = 'linked_id';
-});
+document.addEventListener('DOMContentLoaded', syncLinkedId);
 </script>
 
 @endif

--- a/templates/default/domain_admin/user_edit.blade.php
+++ b/templates/default/domain_admin/user_edit.blade.php
@@ -1,0 +1,130 @@
+{{-- Domain Admin: edit customer or biller login account --}}
+@if(!empty($_POST['email']) && form_submitted())
+    @include('templates.default.domain_admin.user_save')
+@else
+
+@php
+    $u       = $domainUser ?? [];
+    $curRole = $u['role_name'] ?? 'customer';
+    $curId   = (int) ($u['user_id'] ?? 0);
+@endphp
+
+<form method="post" action="index.php?module=domain_admin&view=user_edit&id={{ urlencode($u['id'] ?? '') }}"
+      class="needs-validation" novalidate id="domainUserForm">
+<div class="card">
+    <div class="card-body">
+
+        {{-- Role selector --}}
+        <div class="mb-3">
+            <label class="form-label fw-medium">Account Type</label>
+            <div class="d-flex gap-3">
+                <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="role_key" value="customer"
+                           @if($curRole === 'customer') checked @endif
+                           onchange="toggleLinkedDropdown(this.value)">
+                    <span class="form-check-label">
+                        <i class="ti ti-address-book me-1"></i>Customer
+                    </span>
+                </label>
+                <label class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="role_key" value="biller"
+                           @if($curRole === 'biller') checked @endif
+                           onchange="toggleLinkedDropdown(this.value)">
+                    <span class="form-check-label">
+                        <i class="ti ti-building-store me-1"></i>Biller
+                    </span>
+                </label>
+            </div>
+        </div>
+
+        {{-- Link to customer --}}
+        <div class="mb-3" id="customerDropdown" @if($curRole === 'biller') style="display:none" @endif>
+            <label class="form-label">Link to Customer</label>
+            <select name="linked_id" id="linked_id_customer" class="form-select">
+                <option value="">— select customer —</option>
+                @foreach(($customers ?? []) as $c)
+                    <option value="{{ $c['id'] }}"
+                            @if($curRole === 'customer' && (int)$c['id'] === $curId) selected @endif>
+                        {{ $c['name'] }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+
+        {{-- Link to biller --}}
+        <div class="mb-3" id="billerDropdown" @if($curRole !== 'biller') style="display:none" @endif>
+            <label class="form-label">Link to Biller</label>
+            <select name="linked_id_biller" id="linked_id_biller" class="form-select">
+                <option value="">— select biller —</option>
+                @foreach(($billers ?? []) as $b)
+                    <option value="{{ $b['id'] }}"
+                            @if($curRole === 'biller' && (int)$b['id'] === $curId) selected @endif>
+                        {{ $b['name'] }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+
+        <hr class="my-3">
+
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" value="{{ $u['name'] ?? '' }}" class="form-control" autocomplete="off" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email <i class="ti ti-asterisk text-danger" style="font-size:.7rem;"></i></label>
+            <input type="email" name="email" value="{{ $u['email'] ?? '' }}" class="form-control"
+                   required autocomplete="off" />
+            <div class="invalid-feedback">A valid email is required.</div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">New Password
+                <span class="text-secondary small">(leave blank to keep current)</span>
+            </label>
+            <input type="password" name="password_field" class="form-control" autocomplete="new-password" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="enabled" class="form-select">
+                <option value="1" @if(($u['enabled'] ?? 1)) selected @endif>Enabled</option>
+                <option value="0" @if(!($u['enabled'] ?? 1)) selected @endif>Disabled</option>
+            </select>
+        </div>
+    </div>
+    <div class="card-footer">
+        <div class="d-flex">
+            <a href="index.php?module=domain_admin&view=users" class="btn btn-link">Cancel</a>
+            <button type="submit" class="btn btn-primary ms-auto">
+                <i class="ti ti-check me-1"></i>Save Changes
+            </button>
+        </div>
+    </div>
+</div>
+<input type="hidden" name="op" value="update_domain_user" />
+<input type="hidden" name="id" value="{{ $u['id'] ?? '' }}" />
+<input type="hidden" name="csrfprotectionbysr" value="{{ $domainUserSaveCsrfToken ?? '' }}" />
+</form>
+
+<script>
+function toggleLinkedDropdown(role) {
+    var customerDiv = document.getElementById('customerDropdown');
+    var billerDiv   = document.getElementById('billerDropdown');
+    if (role === 'biller') {
+        customerDiv.style.display = 'none';
+        billerDiv.style.display   = '';
+    } else {
+        customerDiv.style.display = '';
+        billerDiv.style.display   = 'none';
+    }
+}
+
+document.getElementById('domainUserForm').addEventListener('submit', function() {
+    var role = document.querySelector('input[name="role_key"]:checked').value;
+    var src  = role === 'biller'
+               ? document.getElementById('linked_id_biller')
+               : document.getElementById('linked_id_customer');
+    src.name = 'linked_id';
+});
+</script>
+
+@endif

--- a/templates/default/domain_admin/user_save.blade.php
+++ b/templates/default/domain_admin/user_save.blade.php
@@ -1,0 +1,17 @@
+{{-- Domain Admin: save result --}}
+@if(!empty($saveError))
+    <div class="alert alert-danger">
+        <i class="ti ti-alert-circle me-1"></i>{{ $saveError }}
+    </div>
+    <a href="javascript:history.back()" class="btn btn-outline-secondary me-2">
+        <i class="ti ti-arrow-left me-1"></i>Go Back
+    </a>
+    <a href="index.php?module=domain_admin&view=users" class="btn btn-outline-primary">
+        <i class="ti ti-users me-1"></i>All Accounts
+    </a>
+@elseif($saved ?? false)
+    <div class="alert alert-success">
+        <i class="ti ti-check me-1"></i>Account saved successfully.
+    </div>
+    <meta http-equiv="refresh" content="1;URL=index.php?module=domain_admin&view=users" />
+@endif

--- a/templates/default/domain_admin/users.blade.php
+++ b/templates/default/domain_admin/users.blade.php
@@ -1,0 +1,97 @@
+{{-- Domain Admin: list customer and biller login accounts --}}
+@php
+    $filter = get('filter') ?? '';
+    $filtered = collect($domainUsers ?? [])->filter(function($u) use ($filter) {
+        return !$filter || $u['role_name'] === $filter;
+    })->values()->all();
+@endphp
+
+<div class="card">
+    {{-- Filter tabs --}}
+    <div class="card-header">
+        <ul class="nav nav-tabs card-header-tabs">
+            <li class="nav-item">
+                <a class="nav-link @if(!$filter) active @endif"
+                   href="index.php?module=domain_admin&view=users">All</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link @if($filter === 'customer') active @endif"
+                   href="index.php?module=domain_admin&view=users&filter=customer">
+                    <i class="ti ti-address-book me-1"></i>Customers
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link @if($filter === 'biller') active @endif"
+                   href="index.php?module=domain_admin&view=users&filter=biller">
+                    <i class="ti ti-building-store me-1"></i>Billers
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    @if(empty($filtered))
+        <div class="card-body">
+            <div class="empty">
+                <div class="empty-icon"><i class="ti ti-users-group" style="font-size:3rem;"></i></div>
+                <p class="empty-title">No login accounts yet</p>
+                <p class="empty-subtitle text-secondary">
+                    Create a login to give a customer or biller portal access.
+                </p>
+                <div class="empty-action">
+                    <a href="index.php?module=domain_admin&view=user_add" class="btn btn-primary">
+                        <i class="ti ti-plus me-1"></i>Add Login Account
+                    </a>
+                </div>
+            </div>
+        </div>
+    @else
+        <div class="table-responsive">
+            <table class="table table-vcenter card-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Role</th>
+                        <th>Linked To</th>
+                        <th>Status</th>
+                        <th class="w-1"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($filtered as $u)
+                    @php
+                        $linkedName = $u['role_name'] === 'customer'
+                            ? ($u['customer_name'] ?? '<span class="text-danger">unlinked</span>')
+                            : ($u['biller_name']   ?? '<span class="text-danger">unlinked</span>');
+                        $roleIcon = $u['role_name'] === 'customer' ? 'ti-address-book' : 'ti-building-store';
+                        $roleBadge = $u['role_name'] === 'customer' ? 'bg-blue-lt' : 'bg-orange-lt';
+                    @endphp
+                    <tr>
+                        <td class="fw-medium">{{ $u['name'] ?: '—' }}</td>
+                        <td class="text-secondary">{{ $u['email'] }}</td>
+                        <td>
+                            <span class="badge {{ $roleBadge }}">
+                                <i class="ti {{ $roleIcon }} me-1"></i>{{ ucfirst($u['role_name']) }}
+                            </span>
+                        </td>
+                        <td>{!! $linkedName !!}</td>
+                        <td>
+                            @if($u['enabled'])
+                                <span class="badge bg-success-lt">Enabled</span>
+                            @else
+                                <span class="badge bg-danger-lt">Disabled</span>
+                            @endif
+                        </td>
+                        <td>
+                            <a href="index.php?module=domain_admin&view=user_edit&id={{ urlencode($u['id']) }}"
+                               class="btn btn-sm btn-outline-secondary">
+                                <i class="ti ti-edit me-1"></i>Edit
+                            </a>
+                        </td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+</div>

--- a/templates/default/domain_admin/users.blade.php
+++ b/templates/default/domain_admin/users.blade.php
@@ -1,9 +1,9 @@
 {{-- Domain Admin: list customer and biller login accounts --}}
 @php
     $filter = get('filter') ?? '';
-    $filtered = collect($domainUsers ?? [])->filter(function($u) use ($filter) {
+    $filtered = array_values(array_filter($domainUsers ?? [], function($u) use ($filter) {
         return !$filter || $u['role_name'] === $filter;
-    })->values()->all();
+    }));
 @endphp
 
 <div class="card">

--- a/templates/default/menu.blade.php
+++ b/templates/default/menu.blade.php
@@ -172,6 +172,31 @@
 
                 </ul>
                 <ul class="navbar-nav ms-md-auto">
+                    {{-- Domain Admin (domain_administrator + administrator) --}}
+                    @if(isset($_SESSION['SI_Auth']['role_name']) && in_array($_SESSION['SI_Auth']['role_name'], ['domain_administrator', 'administrator'], true))
+                    <li class="nav-item dropdown @if(($module ?? '') == 'domain_admin') active @endif">
+                        <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="outside" role="button" aria-expanded="false">
+                            <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="ti ti-users-group"></i></span>
+                            <span class="nav-link-title">Domain Admin</span>
+                        </a>
+                        <div class="dropdown-menu dropdown-menu-lg-end">
+                            <a class="dropdown-item @if(($module ?? '') == 'domain_admin' && ($view ?? '') == 'index') active @endif"
+                               href="index.php?module=domain_admin&view=index">
+                                <i class="ti ti-layout-dashboard me-2 text-secondary"></i>Dashboard
+                            </a>
+                            <div class="dropdown-divider"></div>
+                            <a class="dropdown-item @if(($module ?? '') == 'domain_admin' && ($view ?? '') == 'users') active @endif"
+                               href="index.php?module=domain_admin&view=users">
+                                <i class="ti ti-users me-2 text-secondary"></i>Login Accounts
+                            </a>
+                            <a class="dropdown-item @if(($module ?? '') == 'domain_admin' && ($view ?? '') == 'user_add') active @endif"
+                               href="index.php?module=domain_admin&view=user_add">
+                                <i class="ti ti-user-plus me-2 text-secondary"></i>Add Login Account
+                            </a>
+                        </div>
+                    </li>
+                    @endif
+
                     {{-- Admin (administrator role only) --}}
                     @if(isset($_SESSION['SI_Auth']['role_name']) && $_SESSION['SI_Auth']['role_name'] === 'administrator')
                     <li class="nav-item dropdown @if(($module ?? '') == 'admin') active @endif">
@@ -313,12 +338,16 @@
         $page_title = isset($page_title_lang_keys[$page_title_key]) && isset($LANG[$page_title_lang_keys[$page_title_key]])
             ? $LANG[$page_title_lang_keys[$page_title_key]]
             : ($tmp_lang_view . ' ' . $tmp_lang_module);
-        // Override titles for admin module
+        // Override titles for admin and domain_admin modules
         $admin_titles = [
-            'admin_index'       => 'Admin Dashboard',
-            'admin_domains'     => 'Manage Domains',
-            'admin_domain_add'  => 'Add Domain',
-            'admin_domain_edit' => 'Edit Domain',
+            'admin_index'            => 'Admin Dashboard',
+            'admin_domains'          => 'Manage Domains',
+            'admin_domain_add'       => 'Add Domain',
+            'admin_domain_edit'      => 'Edit Domain',
+            'domain_admin_index'     => 'Domain Admin Dashboard',
+            'domain_admin_users'     => 'Login Accounts',
+            'domain_admin_user_add'  => 'Add Login Account',
+            'domain_admin_user_edit' => 'Edit Login Account',
         ];
         if (isset($admin_titles[$page_title_key])) {
             $page_title = $admin_titles[$page_title_key];
@@ -407,6 +436,18 @@
                     @elseif(($module ?? '') == 'admin' && in_array($view ?? '', ['domain_add', 'domain_edit']))
                         <a href="index.php?module=admin&view=domains" class="btn btn-outline-secondary">
                             <i class="ti ti-arrow-left me-1"></i>All Domains
+                        </a>
+                    @elseif(($module ?? '') == 'domain_admin' && ($view ?? '') == 'index')
+                        <a href="index.php?module=domain_admin&view=users" class="btn btn-outline-secondary">
+                            <i class="ti ti-users me-1"></i>Login Accounts
+                        </a>
+                    @elseif(($module ?? '') == 'domain_admin' && ($view ?? '') == 'users')
+                        <a href="index.php?module=domain_admin&view=user_add" class="btn btn-primary">
+                            <i class="ti ti-plus me-1"></i>Add Login Account
+                        </a>
+                    @elseif(($module ?? '') == 'domain_admin' && in_array($view ?? '', ['user_add', 'user_edit']))
+                        <a href="index.php?module=domain_admin&view=users" class="btn btn-outline-secondary">
+                            <i class="ti ti-arrow-left me-1"></i>All Accounts
                         </a>
                     @elseif(($module ?? '') == 'reports' && ($view ?? '') != 'index')
                         <a href="index.php?module=reports&view=index" class="btn btn-outline-secondary">


### PR DESCRIPTION
## Summary

- **New `domain_admin` module** — accessible to `domain_administrator` and `administrator` roles only (ACL resource + hard role check in every PHP file)
- **Dashboard** (`?module=domain_admin&view=index`) — stat cards for customer accounts, biller accounts, and unlinked customers/billers with quick-add links
- **Login accounts list** (`?module=domain_admin&view=users`) — filterable by All / Customers / Billers; shows linked entity name and enabled badge
- **Add account** (`?module=domain_admin&view=user_add`) — role radio (Customer / Biller) shows/hides the relevant linked-entity dropdown; hidden `linked_id` field kept in sync via `syncLinkedId()`; only `customer` (role 5) and `biller` (role 6) roles assignable
- **Edit account** (`?module=domain_admin&view=user_edit&id=X`) — same form pre-populated; password field optional (blank = keep current)
- All DB writes validate that the linked customer/biller belongs to `auth_session->domain_id`; CSRF-protected throughout
- Menu: **Domain Admin** dropdown (users-group icon) rendered only for `domain_administrator` and `administrator` sessions

## Bug fixes (same branch)

- `users.blade.php`: replaced `collect()` (Laravel-only) with `array_values(array_filter(...))`
- `user_add/edit.blade.php`: added `name="submit"` to submit buttons so `form_submitted()` returns true on POST
- `user_add/edit.blade.php`: replaced fragile DOM-element rename-on-submit with a hidden `<input name="linked_id">` synced on dropdown change and `DOMContentLoaded`

## Test plan

- [ ] Log in as `domain_administrator` — **Domain Admin** dropdown appears in nav; **Admin** dropdown does not
- [ ] Log in as `administrator` — both **Admin** and **Domain Admin** dropdowns appear
- [ ] Log in as `user` / `operator` — neither dropdown appears; direct URL returns Access Denied
- [ ] Add a customer login account: select Customer role → customer dropdown populates → submit → user created with `role_id=5` and correct `user_id`
- [ ] Add a biller login account: switch radio to Biller → biller dropdown shows, customer dropdown hides → submit correctly
- [ ] Edit account: change linked entity and/or password; leave password blank → password unchanged
- [ ] Login accounts list filters correctly on All / Customers / Billers tabs

https://claude.ai/code/session_01UNTRwhsv3KSxYbP2Edhtiv